### PR TITLE
INTYGFV-14332: Fix disappearing sign button

### DIFF
--- a/packages/webcert/src/feature/certificate/Certificate.tsx
+++ b/packages/webcert/src/feature/certificate/Certificate.tsx
@@ -29,6 +29,8 @@ const Wrapper = styled.div`
   padding-right: 16px;
   padding-left: 16px;
 
+  -webkit-transform: translateZ(0); // Fix for disappearing sign button INTYGFV-14332
+
   .contentPaperWrapper {
     padding-left: 32px;
     padding-right: 32px;


### PR DESCRIPTION
Fixes strange rendering bug in Chromium (affects Chrome and Edge) where the sign button disappears after clicking it (setting active focus styles with outline) and subsequently scrolling up and clicking on a part of the document (must be the top part visible within one viewport unit). This is a known issue in Chromium which also concerns fixed or absolutely positioned elements (https://bugs.chromium.org/p/chromium/issues/detail?id=335442)