### PR TITLE
INTYGFV-14421: Ensure complements are rendered after all sub questions

### DIFF
--- a/packages/common/src/utils/certificateUtils.ts
+++ b/packages/common/src/utils/certificateUtils.ts
@@ -110,3 +110,8 @@ export const getComplementedByCertificateRelation = (certificateMetadata: Certif
     (r) => r.type === CertificateRelationType.COMPLEMENTED && r.status !== CertificateStatus.REVOKED
   )
 }
+
+interface Indexable {
+  index: number
+}
+export const sortByIndex = (a: Indexable, b: Indexable) => a.index - b.index

--- a/packages/common/src/utils/validationUtils.ts
+++ b/packages/common/src/utils/validationUtils.ts
@@ -25,6 +25,7 @@ import {
   ValueIcf,
   ValueText,
   ResourceLinkType,
+  sortByIndex,
 } from '..'
 import { ValueDateRange } from '@frontend/common'
 
@@ -294,7 +295,7 @@ export const getSortedValidationErrorSummary = (
     }
   }
 
-  result.sort((a, b) => a.index - b.index)
+  result.sort(sortByIndex)
 
   result = addCareUnitValidationErrors(result, certificate.metadata.careUnitValidationErrors)
 

--- a/packages/webcert/src/feature/certificate/Certificate.tsx
+++ b/packages/webcert/src/feature/certificate/Certificate.tsx
@@ -79,11 +79,11 @@ const Certificate: React.FC = () => {
         {certificateStructure &&
           certificateStructure
             .filter((data) => filterHidden(data))
-            .map((data, index) => {
+            .map((data) => {
               if (data.component === ConfigTypes.CATEGORY) {
-                return <Category key={index} id={data.ids[0]} />
+                return <Category key={data.id} id={data.id} />
               } else {
-                return <QuestionWithSubQuestions key={index} questionIds={data.ids} />
+                return <QuestionWithSubQuestions key={data.id} questionIds={[data.id, ...data.subQuestionIds]} />
               }
             })}
         <CareUnit />

--- a/packages/webcert/src/feature/certificate/Certificate.tsx
+++ b/packages/webcert/src/feature/certificate/Certificate.tsx
@@ -22,6 +22,7 @@ import SigningForm from './Signing/SigningForm'
 import _ from 'lodash'
 import { CustomTooltip } from '@frontend/common/src'
 import ResponsibleHospName from './ResponsibleHospName'
+import { QuestionWithSubQuestions } from './Question/QuestionWithSubQuestions'
 
 const Wrapper = styled.div`
   overflow-y: auto;
@@ -78,11 +79,11 @@ const Certificate: React.FC = () => {
         {certificateStructure &&
           certificateStructure
             .filter((data) => filterHidden(data))
-            .map((data) => {
+            .map((data, index) => {
               if (data.component === ConfigTypes.CATEGORY) {
-                return <Category key={data.id} id={data.id} />
+                return <Category key={index} id={data.ids[0]} />
               } else {
-                return <Question key={data.id} id={data.id} />
+                return <QuestionWithSubQuestions key={index} questionIds={data.ids} />
               }
             })}
         <CareUnit />

--- a/packages/webcert/src/feature/certificate/Inputs/UeRadioGroupOptionalDropdown.tsx
+++ b/packages/webcert/src/feature/certificate/Inputs/UeRadioGroupOptionalDropdown.tsx
@@ -12,6 +12,7 @@ import { updateCertificateDataElement } from '../../../store/certificate/certifi
 import { useAppDispatch } from '../../../store/store'
 import Question from '../Question/Question'
 import { css, FlattenSimpleInterpolation } from 'styled-components/macro'
+import QuestionWrapper from '../Question/QuestionWrapper'
 
 const dropDownStyles: FlattenSimpleInterpolation = css`
   padding: 0 !important;
@@ -72,12 +73,9 @@ const UeRadioGroupOptionalDropdown: React.FC<Props> = ({ question, disabled }) =
           }
         />
         {radio.dropdownQuestionId && (
-          <Question
-            additionalWrapperStyles={dropDownStyles}
-            key={radio.dropdownQuestionId}
-            id={radio.dropdownQuestionId}
-            disableHighlight={true}
-          />
+          <QuestionWrapper additionalStyles={dropDownStyles}>
+            <Question key={radio.dropdownQuestionId} id={radio.dropdownQuestionId} />
+          </QuestionWrapper>
         )}
       </React.Fragment>
     ))

--- a/packages/webcert/src/feature/certificate/Question/Question.tsx
+++ b/packages/webcert/src/feature/certificate/Question/Question.tsx
@@ -2,25 +2,8 @@ import * as React from 'react'
 import { useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import UeRadio from '../Inputs/UeRadio'
-import {
-  Accordion,
-  CertificateDataConfig,
-  CertificateDataElement,
-  CertificateDataElementStyleEnum,
-  ConfigTypes,
-  Expandable,
-  Icon,
-  MandatoryIcon,
-  UvText,
-} from '@frontend/common'
-import {
-  getComplements,
-  getComplementsIncludingSubQuestions,
-  getIsEditable,
-  getIsLocked,
-  getQuestion,
-} from '../../../store/certificate/certificateSelectors'
-import QuestionWrapper from './QuestionWrapper'
+import { Accordion, CertificateDataConfig, CertificateDataElement, ConfigTypes, Icon, MandatoryIcon, UvText } from '@frontend/common'
+import { getIsEditable, getIsLocked, getQuestion } from '../../../store/certificate/certificateSelectors'
 import UeTextArea from '../Inputs/UeTextArea'
 import UeCheckboxGroup from '../Inputs/UeCheckboxGroup'
 import UeCheckbox from '../Inputs/UeCheckbox'
@@ -28,51 +11,24 @@ import UeDropdown from '../Inputs/UeDropdown'
 import UeRadioGroup from '../Inputs/UeRadioGroup'
 import UeCheckboxDateGroup from '../Inputs/UeCheckboxDateGroup'
 import { UeSickLeavePeriod } from '../Inputs/UeSickLeavePeriod/UeSickLeavePeriod'
-import styled, { css } from 'styled-components'
+import { css } from 'styled-components'
 import UeIcf from '../Inputs/UeIcf'
 import _ from 'lodash'
 import ReactTooltip from 'react-tooltip'
 import UeRadioGroupOptionalDropdown from '../Inputs/UeRadioGroupOptionalDropdown'
-import { FlattenSimpleInterpolation } from 'styled-components/macro'
 import UeDiagnoses from '../Inputs/UeDiagnosis/UeDiagnoses'
 
 interface QuestionProps {
   id: string
-  additionalWrapperStyles?: FlattenSimpleInterpolation
-  disableHighlight?: boolean
-}
-
-interface HighlightedProps {
-  highlight: boolean
+  className?: string
 }
 
 const mandatoryIconAdditionalStyles = css`
   top: -5px;
 `
 
-const Complement = styled.div`
-  display: flex;
-  align-items: top;
-  justify-content: space-between;
-  padding: 5px;
-`
-
-const Wrapper = styled.div`
-  display: flex;
-  justify-content: space-between;
-`
-
-const Highlighted = styled.div<HighlightedProps>`
-  border-radius: ${(props) => (props.highlight ? '0.1875px' : '')};
-  outline: ${(props) => (props.highlight ? '1.5px solid #01a5a3' : '')};
-  margin-top: ${(props) => (props.highlight ? '1.5px' : '')};
-  margin-left: ${(props) => (props.highlight ? '1.5px' : '')};
-`
-
-const Question: React.FC<QuestionProps> = ({ id, additionalWrapperStyles, disableHighlight }) => {
+const Question: React.FC<QuestionProps> = ({ id, className }) => {
   const question = useSelector(getQuestion(id), _.isEqual)
-  const complements = useSelector(getComplements(id), _.isEqual)
-  const complementsIncludingSubquestions = useSelector(getComplementsIncludingSubQuestions(id), _.isEqual)
   const isEditable = useSelector(getIsEditable)
   const disabled = useSelector(getIsLocked) || (question?.disabled as boolean) || !isEditable
   const displayMandatory = (!question?.readOnly && question?.mandatory && !question.disabled) ?? false
@@ -165,33 +121,10 @@ const Question: React.FC<QuestionProps> = ({ id, additionalWrapperStyles, disabl
   }
 
   return (
-    <Highlighted highlight={complementsIncludingSubquestions.length > 0 && !disableHighlight}>
-      <Expandable isExpanded={question.visible} additionalStyles={'questionWrapper'}>
-        <QuestionWrapper
-          additionalStyles={additionalWrapperStyles}
-          highlighted={question.style === CertificateDataElementStyleEnum.HIGHLIGHTED}>
-          {getQuestionComponent(question.config, displayMandatory, question.readOnly)}
-          <div className={'iu-mt-300'}>
-            {question.readOnly ? getUnifiedViewComponent(question) : getUnifiedEditComponent(question, disabled)}
-          </div>
-          {complements.map((complement, index) => (
-            <div key={index} className={`ic-alert ic-alert--status ic-alert--info iu-p-none iu-my-400`}>
-              <Complement key={complement.valueId} className={'iu-fullwidth '}>
-                <i className={`ic-alert__icon ic-info-icon iu-m-none`} />
-                <div className={'iu-fullwidth iu-pl-300 iu-fs-200'}>
-                  <Wrapper>
-                    <p className={'iu-fw-heading'}>{'Kompletteringsbegäran:'}</p>
-                  </Wrapper>
-                  <Wrapper>
-                    <div className={'iu-fullwidth'}>{complement.message}</div>
-                  </Wrapper>
-                </div>
-              </Complement>
-            </div>
-          ))}
-        </QuestionWrapper>
-      </Expandable>
-    </Highlighted>
+    <div className={className}>
+      {getQuestionComponent(question.config, displayMandatory, question.readOnly)}
+      <div className="iu-mt-300">{question.readOnly ? getUnifiedViewComponent(question) : getUnifiedEditComponent(question, disabled)}</div>
+    </div>
   )
 }
 

--- a/packages/webcert/src/feature/certificate/Question/QuestionWithSubQuestions.test.tsx
+++ b/packages/webcert/src/feature/certificate/Question/QuestionWithSubQuestions.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import '@testing-library/jest-dom'
+import { configureStore, EnhancedStore } from '@reduxjs/toolkit'
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import reducer from '../../../store/reducers'
+import { certificateMiddleware } from '../../../store/certificate/certificateMiddleware'
+import dispatchHelperMiddleware, { clearDispatchedActions } from '../../../store/test/dispatchHelperMiddleware'
+import { QuestionWithSubQuestions } from './QuestionWithSubQuestions'
+import { updateCertificate, updateCertificateComplements } from '../../../store/certificate/certificateActions'
+import { Complement, getCertificate } from '@frontend/common'
+
+let testStore: EnhancedStore
+
+const renderComponent = () => {
+  render(
+    <Provider store={testStore}>
+      <QuestionWithSubQuestions questionIds={['1.1', '1.2', '1.3']} />
+    </Provider>
+  )
+}
+
+const createComplement = ({ questionId = '', message = '' }): Complement => ({
+  questionId,
+  questionText: 'Intyget är baserat på',
+  valueId: 'undersokningAvPatienten',
+  message,
+})
+
+describe('QuestionWithSubQuestions', () => {
+  beforeEach(() => {
+    clearDispatchedActions()
+    testStore = configureStore({
+      reducer,
+      middleware: (getDefaultMiddleware) => getDefaultMiddleware().prepend(dispatchHelperMiddleware, certificateMiddleware),
+    })
+    testStore.dispatch(updateCertificate(getCertificate()))
+    renderComponent()
+  })
+
+  it('should render all questions', () => {
+    const questions = [
+      'Finns besvär på grund av sjukdom eller skada som medför funktionsnedsättning?',
+      'Beskriv de funktionsnedsättningar som har observerats (undersökningsfynd). Ange, om möjligt, varaktighet.',
+      'En annan text',
+    ]
+
+    questions.forEach((q) => expect(screen.queryByText(q)).toBeInTheDocument())
+  })
+
+  it('should render complements for all questions', () => {
+    const complements = [
+      createComplement({ questionId: '1.1', message: 'Komplettering för 1.1' }),
+      createComplement({ questionId: '1.2', message: 'Komplettering för 1.2' }),
+      createComplement({ questionId: '1.3', message: 'Komplettering för 1.3' }),
+    ]
+    testStore.dispatch(updateCertificateComplements(complements))
+
+    complements.forEach((c) => expect(screen.queryByText(c.message)).toBeInTheDocument())
+  })
+})

--- a/packages/webcert/src/feature/certificate/Question/QuestionWithSubQuestions.tsx
+++ b/packages/webcert/src/feature/certificate/Question/QuestionWithSubQuestions.tsx
@@ -1,0 +1,69 @@
+import { CertificateDataElementStyleEnum, Expandable } from '@frontend/common'
+import { isEqual } from 'lodash'
+import React from 'react'
+import { useSelector } from 'react-redux'
+import styled from 'styled-components'
+import { getComplementsForQuestions, getQuestion } from '../../../store/certificate/certificateSelectors'
+import Question from './Question'
+import QuestionWrapper from './QuestionWrapper'
+
+interface HighlightedProps {
+  highlight: boolean
+}
+
+export const Highlighted = styled.div<HighlightedProps>`
+  ${({ highlight }) =>
+    highlight &&
+    `
+    border-radius: 0.1875px;
+    outline: 1.5px solid #01a5a3;
+    margin-top: 1.5px;
+  `}
+`
+
+export const Complement = styled.div`
+  display: flex;
+  align-items: top;
+  justify-content: space-between;
+  padding: 5px;
+`
+
+const QuestionWithMargin = styled(Question)`
+  & + & {
+    margin-top: 32px;
+  }
+`
+
+interface Props {
+  questionIds: string[]
+}
+
+export const QuestionWithSubQuestions: React.FC<Props> = ({ questionIds }) => {
+  const complements = useSelector(getComplementsForQuestions(questionIds), isEqual)
+  const parentQuestion = useSelector(getQuestion(questionIds[0]), isEqual)
+
+  if (!parentQuestion) return null
+
+  return (
+    <Highlighted highlight={complements.length > 0}>
+      <Expandable isExpanded={parentQuestion.visible} additionalStyles={'questionWrapper'}>
+        <QuestionWrapper highlighted={parentQuestion.style === CertificateDataElementStyleEnum.HIGHLIGHTED}>
+          {questionIds.map((id) => (
+            <QuestionWithMargin key={id} id={id} />
+          ))}
+          {complements.map((complement, index) => (
+            <div key={index} className="ic-alert ic-alert--status ic-alert--info iu-p-none iu-my-400">
+              <Complement>
+                <i className="ic-alert__icon ic-info-icon iu-m-none" />
+                <div className="iu-fullwidth iu-pl-300 iu-fs-200">
+                  <p className="iu-fw-heading">Kompletteringsbegäran:</p>
+                  <div>{complement.message}</div>
+                </div>
+              </Complement>
+            </div>
+          ))}
+        </QuestionWrapper>
+      </Expandable>
+    </Highlighted>
+  )
+}

--- a/packages/webcert/src/store/certificate/certificateSelectors.test.ts
+++ b/packages/webcert/src/store/certificate/certificateSelectors.test.ts
@@ -1,0 +1,58 @@
+import { CertificateDataElement, ConfigTypes } from '@frontend/common'
+import { RootState } from '../store'
+import { getCertificateDataElements } from './certificateSelectors'
+
+const createDataElement = ({ id = '', parent = '', type = ConfigTypes.UE_ICF, index = 0 }): CertificateDataElement => ({
+  id,
+  config: { type, text: '', description: '' },
+  parent,
+  index,
+  visible: true,
+  readOnly: false,
+  mandatory: false,
+  value: null,
+  validation: [],
+  validationErrors: [],
+})
+
+const getState = (): RootState =>
+  (({
+    ui: {
+      uiCertificate: {
+        certificate: {
+          data: {
+            '1': createDataElement({ id: '1', parent: 'funktionsnedsattning', index: 3 }),
+            '1.2': createDataElement({ id: '1.2', parent: '1', index: 5 }),
+            '1.1': createDataElement({ id: '1.1', parent: '1', index: 4 }),
+            '1.3': createDataElement({ id: '1.3', parent: '1', index: 6 }),
+            '28': createDataElement({ id: '28', parent: 'sysselsattning', index: 1 }),
+            funktionsnedsattning: createDataElement({ id: 'funktionsnedsattning', type: ConfigTypes.CATEGORY, index: 2 }),
+            sysselsattning: createDataElement({ id: 'sysselsattning', type: ConfigTypes.CATEGORY, index: 0 }),
+          },
+        },
+      },
+    },
+  } as unknown) as RootState)
+
+describe('certificateSelectors', () => {
+  describe('getCertificateDataElements', () => {
+    it('should group sub questions with parent question', () => {
+      const elements = getCertificateDataElements(getState())
+
+      expect(elements.length).toBe(4)
+    })
+
+    it('should not group categories with sub questions', () => {
+      const elements = getCertificateDataElements(getState())
+
+      expect(elements[0].ids).toEqual(['sysselsattning'])
+    })
+
+    it('should sort categories, questions and sub questions by index', () => {
+      const elements = getCertificateDataElements(getState())
+      const ids = elements.map((el) => el.ids).reduce((acc, curr) => acc.concat(curr), [])
+
+      expect(ids).toEqual(['sysselsattning', '28', 'funktionsnedsattning', '1', '1.1', '1.2', '1.3'])
+    })
+  })
+})

--- a/packages/webcert/src/store/certificate/certificateSelectors.test.ts
+++ b/packages/webcert/src/store/certificate/certificateSelectors.test.ts
@@ -45,12 +45,12 @@ describe('certificateSelectors', () => {
     it('should not group categories with sub questions', () => {
       const elements = getCertificateDataElements(getState())
 
-      expect(elements[0].ids).toEqual(['sysselsattning'])
+      expect(elements[0].subQuestionIds).toEqual([])
     })
 
     it('should sort categories, questions and sub questions by index', () => {
       const elements = getCertificateDataElements(getState())
-      const ids = elements.map((el) => el.ids).reduce((acc, curr) => acc.concat(curr), [])
+      const ids = elements.map((el) => [el.id, ...el.subQuestionIds]).reduce((acc, curr) => acc.concat(curr), [])
 
       expect(ids).toEqual(['sysselsattning', '28', 'funktionsnedsattning', '1', '1.1', '1.2', '1.3'])
     })

--- a/packages/webcert/src/store/certificate/certificateSelectors.ts
+++ b/packages/webcert/src/store/certificate/certificateSelectors.ts
@@ -9,14 +9,17 @@ import {
   CertificateRelationType,
   CertificateStatus,
   Complement,
+  ConfigTypes,
   ResourceLink,
   ResourceLinkType,
   Unit,
   ValidationError,
   ValidationErrorSummary,
+  Patient,
+  PersonId,
 } from '@frontend/common'
-import { Patient, PersonId } from '@frontend/common/src'
 import { getSortedValidationErrorSummary } from '@frontend/common/src/utils/validationUtils'
+import { sortByIndex } from '@frontend/common/src/utils/certificateUtils'
 import { SigningData } from './certificateActions'
 
 export const getIsShowSpinner = (state: RootState): boolean => state.ui.uiCertificate.spinner
@@ -48,6 +51,9 @@ export const getComplements = (questionId: string) => (state: RootState): Comple
 
 export const getComplementsIncludingSubQuestions = (questionId: string) => (state: RootState): Complement[] =>
   state.ui.uiCertificate.complements.filter((complement) => complement.questionId === questionId.split('.')[0])
+
+export const getComplementsForQuestions = (questionIds: string[]) => (state: RootState): Complement[] =>
+  state.ui.uiCertificate.complements.filter((complement) => questionIds.includes(complement.questionId))
 
 export const getGotoId = (state: RootState): string | undefined => state.ui.uiCertificate.gotoCertificateDataElement?.questionId
 
@@ -104,13 +110,13 @@ export const getCertificateMetaData = (state: RootState): CertificateMetadata | 
 }
 
 export interface CertificateStructure {
-  id: string
+  ids: string[]
   component: string
   index: number
   style?: CertificateDataElementStyleEnum
 }
 
-const certificateStructure: CertificateStructure[] = []
+let certificateStructure: CertificateStructure[] = []
 export const getCertificateDataElements = createSelector<RootState, Certificate | undefined, CertificateStructure[]>(
   getCertificate,
   (certificate) => {
@@ -119,16 +125,29 @@ export const getCertificateDataElements = createSelector<RootState, Certificate 
       return []
     }
 
-    for (const questionId in certificate.data) {
-      certificateStructure.push({
-        id: certificate.data[questionId].id,
-        component: certificate.data[questionId].config.type,
-        index: certificate.data[questionId].index,
-        style: certificate.data[questionId].style,
-      })
-    }
+    const elements = Object.values(certificate.data)
 
-    certificateStructure.sort((a, b) => a.index - b.index)
+    certificateStructure = elements.reduce((structure: CertificateStructure[], element: CertificateDataElement) => {
+      if (structure.some((s) => s.ids.includes(element.id))) return structure
+
+      const subQuestionIds = elements
+        .filter(() => element.config.type !== ConfigTypes.CATEGORY)
+        .filter((el) => el.config.type !== ConfigTypes.CATEGORY)
+        .filter((el) => el.parent === element.id)
+        .sort(sortByIndex)
+        .map((el) => el.id)
+
+      structure.push({
+        ids: [element.id, ...subQuestionIds],
+        component: element.config.type,
+        index: element.index,
+        style: element.style,
+      })
+
+      return structure
+    }, [])
+
+    certificateStructure.sort(sortByIndex)
     return certificateStructure
   }
 )

--- a/packages/webcert/src/store/certificate/certificateSelectors.ts
+++ b/packages/webcert/src/store/certificate/certificateSelectors.ts
@@ -110,7 +110,8 @@ export const getCertificateMetaData = (state: RootState): CertificateMetadata | 
 }
 
 export interface CertificateStructure {
-  ids: string[]
+  id: string
+  subQuestionIds: string[]
   component: string
   index: number
   style?: CertificateDataElementStyleEnum
@@ -128,7 +129,7 @@ export const getCertificateDataElements = createSelector<RootState, Certificate 
     const elements = Object.values(certificate.data)
 
     certificateStructure = elements.reduce((structure: CertificateStructure[], element: CertificateDataElement) => {
-      if (structure.some((s) => s.ids.includes(element.id))) return structure
+      if (structure.some((s) => s.subQuestionIds.includes(element.id))) return structure
 
       const subQuestionIds = elements
         .filter(() => element.config.type !== ConfigTypes.CATEGORY)
@@ -138,7 +139,8 @@ export const getCertificateDataElements = createSelector<RootState, Certificate 
         .map((el) => el.id)
 
       structure.push({
-        ids: [element.id, ...subQuestionIds],
+        id: element.id,
+        subQuestionIds,
         component: element.config.type,
         index: element.index,
         style: element.style,

--- a/packages/webcert/src/store/fmb/fmbReducer.ts
+++ b/packages/webcert/src/store/fmb/fmbReducer.ts
@@ -9,7 +9,7 @@ import {
   updateFMBDiagnosisCodeInfo,
   updateFMBPanelActive,
 } from './fmbActions'
-import { FMBDiagnosisCodeInfo } from '@frontend/common'
+import { FMBDiagnosisCodeInfo, sortByIndex } from '@frontend/common'
 import { ValueDateRangeList, ValueDiagnosisList } from '@frontend/common/src/types/certificate'
 import { FunctionDisabler, toggleFunctionDisabler } from '../../components/utils/functionDisablerUtils'
 
@@ -37,7 +37,7 @@ const fmbReducer = createReducer(initialState, (builder) =>
   builder
     .addCase(updateFMBDiagnosisCodeInfo, (state, action) => {
       state.fmbDiagnosisCodeInfo.push(action.payload)
-      state.fmbDiagnosisCodeInfo.sort((a, b) => a.index - b.index)
+      state.fmbDiagnosisCodeInfo.sort(sortByIndex)
     })
     .addCase(updateFMBPanelActive, (state, action) => {
       state.fmbPanelActive = action.payload


### PR DESCRIPTION
Business rules:
* Request for complements are only sent for main questions
* Notice on request for complements is shown after the main question and
sub questions if any

Note: the code still supports complements for sub questions, I saw no
need rewrite that logic.