### PR TITLE
INTYGFV-14732: Fix margin, padding and layout issues

### DIFF
--- a/packages/webcert/src/components/certificateList/CertificateList.tsx
+++ b/packages/webcert/src/components/certificateList/CertificateList.tsx
@@ -33,7 +33,6 @@ const byFavorite = (a: CertificateTypeViewModel, b: CertificateTypeViewModel): n
 }
 
 const CertificateBox = styled.div`
-  max-width: 75%;
   max-height: 32em;
   overflow-y: auto;
 `
@@ -117,7 +116,7 @@ const CertificateList: React.FC = () => {
   }
 
   return (
-    <div className="ic-container iu-mt-800 iu-flex">
+    <div className="iu-flex">
       <div className="iu-mr-gutter">
         <img src={fileIcon} alt="Ikon för skapa intyg" className="iu-height-600" />
       </div>

--- a/packages/webcert/src/components/commonLayout/CommonLayout.tsx
+++ b/packages/webcert/src/components/commonLayout/CommonLayout.tsx
@@ -20,15 +20,18 @@ const NoFlexGrow = styled.div`
 interface Props {
   header?: React.ReactNode
   subHeader?: React.ReactNode
+  noPadding?: boolean
 }
 
-const CommonLayout: React.FC<Props> = ({ header, subHeader, children }) => {
+const CommonLayout: React.FC<Props> = ({ header, subHeader, children, noPadding = false }) => {
   return (
     <Root>
       <CustomTooltip placement="top" />
       {header && <NoFlexGrow>{header}</NoFlexGrow>}
       {subHeader && <NoFlexGrow>{subHeader}</NoFlexGrow>}
-      <Content>{children}</Content>
+      <Content>
+        <div className={`ic-container ${noPadding === false && 'iu-pt-500'}`}>{children}</div>
+      </Content>
     </Root>
   )
 }

--- a/packages/webcert/src/components/patient/PatientSearch.tsx
+++ b/packages/webcert/src/components/patient/PatientSearch.tsx
@@ -26,7 +26,7 @@ const PatientSearch: React.FC = () => {
     if (enterPress && isPersonIdValid(patientId)) {
       onSubmit()
     }
-  }, [enterPress, onSubmit])
+  }, [enterPress, onSubmit, patientId])
 
   const onChange = (formattedPatientId: string) => {
     dispatch(clearPatientError())
@@ -41,7 +41,7 @@ const PatientSearch: React.FC = () => {
   }
 
   return (
-    <div className="ic-container iu-p-400">
+    <>
       <h2>Patientens personnummer eller samordningsnummer</h2>
       <FormWrapper className="iu-mt-300">
         <PersonIdInput onFormattedChange={onChange} value={patientId} onFocus={onFocus} />
@@ -54,7 +54,7 @@ const PatientSearch: React.FC = () => {
         />
       </FormWrapper>
       <PatientSearchError />
-    </div>
+    </>
   )
 }
 export default PatientSearch

--- a/packages/webcert/src/feature/list/List.tsx
+++ b/packages/webcert/src/feature/list/List.tsx
@@ -11,8 +11,7 @@ import { ResourceLink } from '@frontend/common'
 import styled from 'styled-components/macro'
 
 const ContentWrapper = styled.div`
-  flex: 0 0 100%;
-  padding-right: 30px;
+  width: 100%;
 `
 
 interface Props {
@@ -106,8 +105,8 @@ const List: React.FC<Props> = ({ icon, config, list, filter, title }) => {
 
   return (
     <>
-      <div className="iu-flex iu-pt-500">
-        {icon && <img src={icon} className="iu-mr-gutter iu-height-600" />}
+      <div className="iu-flex">
+        {icon && <img src={icon} alt="" className="iu-mr-gutter iu-height-600" />}
         <ContentWrapper>
           <h3>{title}</h3>
           <ListFilterContainer config={config} filter={filter} />

--- a/packages/webcert/src/page/CertificatePage.tsx
+++ b/packages/webcert/src/page/CertificatePage.tsx
@@ -56,7 +56,8 @@ const CertificatePage: React.FC = () => {
             <CertificateDeletedModal routedFromDeletedCertificate={routedFromDeletedCertificate} />
           </>
         )
-      }>
+      }
+      noPadding={true}>
       {isCertificateDeleted ? (
         <CertificateDeletedHandler />
       ) : (

--- a/packages/webcert/src/page/ListPage.tsx
+++ b/packages/webcert/src/page/ListPage.tsx
@@ -13,8 +13,8 @@ import {
 import { shallowEqual, useDispatch, useSelector } from 'react-redux'
 import List from '../feature/list/List'
 import { getListConfig, performListSearch, updateActiveListType, updateHasUpdatedConfig, updateListConfig } from '../store/list/listActions'
-import { ImageCentered } from '@frontend/common/src'
-import { InfoBox, ListHeader } from '@frontend/common'
+import { ImageCentered, InfoBox, ListHeader } from '@frontend/common/src'
+
 import noDraftsImage from '@frontend/common/src/images/no-drafts-image.svg'
 import noQuestionsImage from '@frontend/common/src/images/no-questions-image.svg'
 import WebcertHeader from '../components/header/WebcertHeader'
@@ -56,7 +56,7 @@ const ListPage: React.FC<Props> = ({ type, excludePageSpecificElements }) => {
     if (hasUpdatedConfig) {
       dispatch(updateListConfig())
     }
-  }, [hasUpdatedConfig])
+  }, [dispatch, hasUpdatedConfig])
 
   useEffect(() => {
     dispatch(updateActiveListType(type))
@@ -68,7 +68,7 @@ const ListPage: React.FC<Props> = ({ type, excludePageSpecificElements }) => {
       dispatch(performListSearch)
       dispatch(updateHasUpdatedConfig(false))
     }
-  }, [dispatch, config, isLoadingListConfig])
+  }, [dispatch, config, isLoadingListConfig, hasUpdatedConfig])
 
   useEffect(() => {
     dispatch(updateShouldRouteAfterDelete(true))
@@ -105,11 +105,7 @@ const ListPage: React.FC<Props> = ({ type, excludePageSpecificElements }) => {
 
   const getList = () => {
     if (error) {
-      return (
-        <div className="iu-pt-300">
-          <InfoBox type="error">Sökningen kunde inte utföras.</InfoBox>
-        </div>
-      )
+      return <InfoBox type="error">Sökningen kunde inte utföras.</InfoBox>
     } else if (isListCompletelyEmpty()) {
       return (
         <ImageCentered imgSrc={getEmptyListIcon()} alt={'Det finns inga resultat i listan.'}>
@@ -132,7 +128,7 @@ const ListPage: React.FC<Props> = ({ type, excludePageSpecificElements }) => {
   }
 
   if (excludePageSpecificElements) {
-    return <div className="ic-container">{getList()}</div>
+    return getList()
   }
 
   return (
@@ -150,7 +146,7 @@ const ListPage: React.FC<Props> = ({ type, excludePageSpecificElements }) => {
         </>
       }>
       <CertificateDeletedModal routedFromDeletedCertificate={routedFromDeletedCertificate} />
-      <div className="ic-container">{getList()}</div>
+      {getList()}
     </CommonLayout>
   )
 }


### PR DESCRIPTION
Fixes inconsistencies for main contents padding/margin, some examples:

| search | create certificate|
|----|----|
| ![2022-07-21 09_03_22-Webcert](https://user-images.githubusercontent.com/28404/180152003-35910d3c-e7a0-43b2-a584-f0944362b3d1.png) | ![2022-07-21 09_08_47-Webcert](https://user-images.githubusercontent.com/28404/180152015-907c32ee-f692-46bc-b834-9d9ebc75d7dc.png) |

Fixed issues with not filling the page

![2022-07-21 09_11_11-Webcert](https://user-images.githubusercontent.com/28404/180152282-32f8e2bd-108b-418e-88ca-2d8dcf54a605.png)

And issues with going over the page limit

| create certificate | certificate page |
|----|----|
| ![2022-07-21 09_05_41-Webcert](https://user-images.githubusercontent.com/28404/180152393-cba7cd47-a184-41e5-99b9-0bc5fcf5a308.png) | ![2022-07-21 09_12_41-Webcert](https://user-images.githubusercontent.com/28404/180152796-dd4c00fc-f805-438c-ba82-7b2c94b5e57b.png) |