### PR TITLE
Bugfix: Infinite loading loop on list page view for unhandled issues

### DIFF
--- a/packages/webcert/src/page/ListPage.tsx
+++ b/packages/webcert/src/page/ListPage.tsx
@@ -68,7 +68,9 @@ const ListPage: React.FC<Props> = ({ type, excludePageSpecificElements }) => {
       dispatch(performListSearch)
       dispatch(updateHasUpdatedConfig(false))
     }
-  }, [dispatch, config, isLoadingListConfig, hasUpdatedConfig])
+    /* eslint-disable react-hooks/exhaustive-deps */
+  }, [dispatch, config, isLoadingListConfig]) // effect needs to be run whenever hasUpdatedConfig updates
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   useEffect(() => {
     dispatch(updateShouldRouteAfterDelete(true))


### PR DESCRIPTION
Apparently the effect needs to be triggered whenever hasUpdatedConfig is
updated regardless whether is has the same values as previous render or
not.