### PR TITLE
INTYGFV-15189: removed available to patient status for signed death and cause of death certificates

### DIFF
--- a/packages/webcert/src/feature/certificate/CertificateHeader/Status/AvailableForPatientStatus.test.tsx
+++ b/packages/webcert/src/feature/certificate/CertificateHeader/Status/AvailableForPatientStatus.test.tsx
@@ -1,11 +1,11 @@
-import React from 'react'
+import { CertificateStatus } from '@frontend/common/src'
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import React from 'react'
 import { Provider } from 'react-redux'
 import store from '../../../../store/store'
 import CertificateHeaderStatuses from './CertificateHeaderStatuses'
-import { CertificateStatus } from '@frontend/common/src'
 import { createCertificateMetadata } from './statusTestUtils'
 
 const renderComponent = (isSigned: boolean, type?: string) => {
@@ -52,6 +52,16 @@ describe('Available for patient status', () => {
 
   it('should not render status if certificate is unsigned', () => {
     renderComponent(false)
+    expect(screen.queryByText('Intyget är tillgängligt för patienten')).not.toBeInTheDocument()
+  })
+
+  it('should not render status if certificate is death certificate', () => {
+    renderComponent(true, 'db')
+    expect(screen.queryByText('Intyget är tillgängligt för patienten')).not.toBeInTheDocument()
+  })
+
+  it('should not render status if certificate is cause of death certificate', () => {
+    renderComponent(true, 'doi')
     expect(screen.queryByText('Intyget är tillgängligt för patienten')).not.toBeInTheDocument()
   })
 

--- a/packages/webcert/src/feature/certificate/CertificateHeader/Status/AvailableForPatientStatus.tsx
+++ b/packages/webcert/src/feature/certificate/CertificateHeader/Status/AvailableForPatientStatus.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
 import { CertificateMetadata, isSigned, StatusWithIcon, TextWithInfoModal } from '@frontend/common'
+import React from 'react'
 import WCDynamicLink from '../../../../utils/WCDynamicLink'
 
 interface Props {
@@ -7,7 +7,7 @@ interface Props {
 }
 
 const AvailableForPatientStatus: React.FC<Props> = ({ certificateMetadata }) => {
-  if (!isSigned(certificateMetadata)) return null
+  if (!isSigned(certificateMetadata) || certificateMetadata.type === 'db' || certificateMetadata.type === 'doi') return null
   const isLisjp = certificateMetadata.type === 'lisjp'
 
   return (


### PR DESCRIPTION
This is a quick fix checking if certificate type is db or doi, and then not displaying status

In the future, a more general solution could be supplying info on this in certificate metadata instead, like we do with the sent to status.