### PR TITLE
added null check to value prop in dropdown

### DIFF
--- a/packages/common/src/components/Inputs/Dropdown.tsx
+++ b/packages/common/src/components/Inputs/Dropdown.tsx
@@ -1,5 +1,5 @@
-import React, { forwardRef } from 'react'
 import classNames from 'classnames'
+import React, { forwardRef } from 'react'
 import styled from 'styled-components'
 
 const DropdownDiv = styled.div`
@@ -18,7 +18,7 @@ interface Props extends React.SelectHTMLAttributes<HTMLSelectElement> {
   label?: string
 }
 
-const Dropdown = forwardRef<HTMLSelectElement, Props>(({ children, id, error, disabled, title, label, ...props }, ref) => (
+const Dropdown = forwardRef<HTMLSelectElement, Props>(({ children, id, error, disabled, title, label, value, ...props }, ref) => (
   <>
     {label !== null ? <label htmlFor={id}>{label}</label> : null}
     <DropdownDiv
@@ -28,7 +28,7 @@ const Dropdown = forwardRef<HTMLSelectElement, Props>(({ children, id, error, di
         dropdown: !error,
         'ic-forms__select--disabled': disabled,
       })}>
-      <DropdownSelect ref={ref} id={id} disabled={disabled} {...props}>
+      <DropdownSelect ref={ref} id={id} disabled={disabled} value={value ?? ''} {...props}>
         {children}
       </DropdownSelect>
     </DropdownDiv>


### PR DESCRIPTION
the dropdown component sometimes renders an error in the console log, due to null in the value parameter. 
I've added a null check, so an empty string is passed instead of null