### PR TITLE
INTYGFV-15421: Fix button alignment error message

### DIFF
--- a/packages/webcert/src/components/error/modals/ErrorModalBase.tsx
+++ b/packages/webcert/src/components/error/modals/ErrorModalBase.tsx
@@ -11,6 +11,14 @@ const Modal = styled.div`
   z-index: 9999;
 `
 
+const ButtonGroup = styled.div`
+  margin-top: 1.875rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+`
+
 interface ErrorModalProps {
   onConfirm?: () => void
   confirmButtonText?: string
@@ -32,15 +40,6 @@ const ErrorModalBase: React.FC<ErrorModalProps> = ({ onConfirm, confirmButtonTex
     setOpen(false)
   }
 
-  const getButtons = () => {
-    return (
-      <>
-        {confirmButtonText && <CustomButton onClick={handleConfirm} text={confirmButtonText} buttonStyle={'primary'} />}
-        <CustomButton onClick={handleClose} text={closeButtonText} />
-      </>
-    )
-  }
-
   return (
     <FocusTrap
       active={open}
@@ -53,7 +52,10 @@ const ErrorModalBase: React.FC<ErrorModalProps> = ({ onConfirm, confirmButtonTex
         <div className="ic-backdrop" onClick={handleClose} />
         <Modal role="alertdialog" className="ic-modal ic-modal--error" aria-labelledby="demo-modal-content">
           <div className="ic-modal__body">{children}</div>
-          <div className="ic-button-group ic-button-group--center">{getButtons()}</div>
+          <ButtonGroup className={confirmButtonText ? 'ic-button-group ic-button-group--center' : ''}>
+            {confirmButtonText && <CustomButton onClick={handleConfirm} text={confirmButtonText} buttonStyle={'primary'} />}
+            <CustomButton onClick={handleClose} text={closeButtonText} />
+          </ButtonGroup>
           <ErrorCopyText errorId={errorData.errorId} />
         </Modal>
       </div>

--- a/packages/webcert/src/components/error/modals/SignCertificateError.tsx
+++ b/packages/webcert/src/components/error/modals/SignCertificateError.tsx
@@ -1,7 +1,7 @@
-import { ModalProps } from './errorUtils'
 import React from 'react'
-import ErrorModalBase from './ErrorModalBase'
 import WCDynamicLink from '../../../utils/WCDynamicLink'
+import ErrorModalBase from './ErrorModalBase'
+import { ModalProps } from './errorUtils'
 
 export const SIGN_CERTIFICATE_ERROR_TITLE = 'Signering misslyckades'
 
@@ -11,8 +11,8 @@ const SignCertificateError: React.FC<ModalProps> = ({ errorData }) => {
       <p>
         <strong>{SIGN_CERTIFICATE_ERROR_TITLE}</strong>
       </p>
+      <p>Intyget har inte signerats. Detta beror på ett tekniskt fel eller att signeringen avbrutits.</p>
       <p>
-        Intyget har inte signerats. Detta beror på ett tekniskt fel eller att signeringen avbrutits. <br />
         Prova igen om en stund. Om problemet kvarstår, kontakta i första hand din lokala IT-avdelning och i andra hand{' '}
         <WCDynamicLink linkKey="ineraKundserviceAnmalFel" />.
       </p>


### PR DESCRIPTION
The padding for error modal is set by the inera css and changing it would probably lead to some other text wrapping at inconvenient places, best left untouched. I made sure that each paragraph has proper spacing and the button should be centered.

![2023-03-27 09_25_20-Webcert](https://user-images.githubusercontent.com/28404/227870116-9a5e5336-7f50-444b-a5ae-7ce8664d6d99.png)
