### PR TITLE
Simplify API by reducing tags

### DIFF
--- a/apps/rehabstod/src/components/SickLeave/RekoStatusDropdown.tsx
+++ b/apps/rehabstod/src/components/SickLeave/RekoStatusDropdown.tsx
@@ -1,9 +1,9 @@
 import { MouseEvent, useState } from 'react'
-import { useGetPopulatedFiltersQuery, useSetRekoStatusMutation } from '../../store/api'
 import { RekoStatus, RekoStatusType } from '../../schemas/sickLeaveSchema'
-import { SelectButton } from '../Form/SelectButton'
+import { useGetSickLeavesFiltersQuery, useSetRekoStatusMutation } from '../../store/api'
 import { useAppSelector } from '../../store/hooks'
 import { getRekoStatusSickLeaveTimestamp } from '../../utils/getRekoStatusSickLeaveTimestamp'
+import { SelectButton } from '../Form/SelectButton'
 
 export function RekoStatusDropdown({
   statusFromSickLeave,
@@ -14,7 +14,7 @@ export function RekoStatusDropdown({
   patientId: string
   endDate: string
 }) {
-  const { data: populatedFilters } = useGetPopulatedFiltersQuery()
+  const { data: populatedFilters } = useGetSickLeavesFiltersQuery()
   const [setRekoStatus] = useSetRekoStatusMutation()
   const [savedRekoStatus, updateSavedRekoStatus] = useState(statusFromSickLeave ? statusFromSickLeave.status.name : 'Ingen')
   const sickLeaveTimestamp = getRekoStatusSickLeaveTimestamp(endDate)

--- a/apps/rehabstod/src/pages/CurrentSickLeaves/CurrentSickLeaves.tsx
+++ b/apps/rehabstod/src/pages/CurrentSickLeaves/CurrentSickLeaves.tsx
@@ -1,27 +1,27 @@
 import { IDSButton } from '@frontend/ids-react-ts'
 import { useEffect, useState } from 'react'
 import { Outlet, useNavigate, useParams } from 'react-router-dom'
+import { EmptyTableAlert } from '../../components/Table/EmptyTableAlert'
 import { Table } from '../../components/Table/Table'
+import { TableHeadingForUnit } from '../../components/Table/heading/TableHeadingForUnit'
+import { TableContentAlert } from '../../components/error/ErrorAlert/TableContentAlert'
+import { UnansweredCommunicationAlert } from '../../components/error/ErrorAlert/UnansweredCommunicationAlert'
 import { UserUrval } from '../../schemas'
-import { useGetPopulatedFiltersQuery, useGetUserQuery, useLazyGetSickLeavesQuery } from '../../store/api'
+import { useGetSickLeavesFiltersQuery, useGetUserQuery, useLazyGetSickLeavesQuery } from '../../store/api'
 import { useAppDispatch, useAppSelector } from '../../store/hooks'
+import { updateShowPersonalInformation } from '../../store/slices/settings.slice'
 import { reset, resetFilters } from '../../store/slices/sickLeave.slice'
 import { SickLeaveColumn } from '../../store/slices/sickLeaveTableColumns.slice'
+import { CurrentSickLeavesTableInfo } from './components/CurrentSickLeavesTableInfo'
 import { Filters } from './components/Filters'
 import { ModifySicknessTableColumns } from './components/ModifySicknessTableColumns'
 import { PrintTable } from './components/PrintTable'
 import { TableBodyRows } from './components/TableBodyRows'
 import { TableHeaderRow } from './components/TableHeaderRow'
-import { CurrentSickLeavesTableInfo } from './components/CurrentSickLeavesTableInfo'
-import { updateShowPersonalInformation } from '../../store/slices/settings.slice'
-import { UnansweredCommunicationAlert } from '../../components/error/ErrorAlert/UnansweredCommunicationAlert'
-import { TableHeadingForUnit } from '../../components/Table/heading/TableHeadingForUnit'
-import { TableContentAlert } from '../../components/error/ErrorAlert/TableContentAlert'
-import { EmptyTableAlert } from '../../components/Table/EmptyTableAlert'
 
 export function CurrentSickLeaves() {
   const { isLoading: userLoading, data: user } = useGetUserQuery()
-  const { data: populatedFilters } = useGetPopulatedFiltersQuery()
+  const { data: populatedFilters } = useGetSickLeavesFiltersQuery()
   const [triggerGetSickLeaves, { isLoading: currentSickLeaveLoading, data: currentSickLeavesInfo, error }] = useLazyGetSickLeavesQuery()
   const { showPersonalInformation } = useAppSelector((state) => state.settings)
   const { encryptedPatientId } = useParams()

--- a/apps/rehabstod/src/pages/CurrentSickLeaves/components/Filters.tsx
+++ b/apps/rehabstod/src/pages/CurrentSickLeaves/components/Filters.tsx
@@ -1,19 +1,19 @@
 import { useDispatch } from 'react-redux'
-import { SickLeaveFilter, SickLeaveLengthInterval } from '../../../schemas/sickLeaveSchema'
-import { useGetPopulatedFiltersQuery } from '../../../store/api'
-import { useAppSelector } from '../../../store/hooks'
-import { updateFilter } from '../../../store/slices/sickLeave.slice'
+import { TableFilter } from '../../../components/Table/TableFilter'
+import { DateRangeFilter } from '../../../components/Table/filter/DateRangeFilter'
 import { DiagnosisFilter } from '../../../components/Table/filter/DiagnosisFilter'
 import { DoctorFilter } from '../../../components/Table/filter/DoctorFilter'
-import { RangeFilter } from '../../../components/Table/filter/RangeFilter'
-import { TimePeriodFilter } from '../../../components/Table/filter/TimePeriodFilter'
 import { MultipleSelectFilterOption } from '../../../components/Table/filter/MultipleSelectFilterOption'
-import { getMultipleSelectPlaceholder } from '../../../components/Table/filter/utils/getMultipleSelectPlaceholder'
+import { RangeFilter } from '../../../components/Table/filter/RangeFilter'
 import { SelectFilter } from '../../../components/Table/filter/SelectFilter'
 import { TextSearchFilter } from '../../../components/Table/filter/TextSearchFilter'
-import { TableFilter } from '../../../components/Table/TableFilter'
+import { TimePeriodFilter } from '../../../components/Table/filter/TimePeriodFilter'
+import { getMultipleSelectPlaceholder } from '../../../components/Table/filter/utils/getMultipleSelectPlaceholder'
 import { DiagnosKapitel } from '../../../schemas/diagnosisSchema'
-import { DateRangeFilter } from '../../../components/Table/filter/DateRangeFilter'
+import { SickLeaveFilter, SickLeaveLengthInterval } from '../../../schemas/sickLeaveSchema'
+import { useGetSickLeavesFiltersQuery } from '../../../store/api'
+import { useAppSelector } from '../../../store/hooks'
+import { updateFilter } from '../../../store/slices/sickLeave.slice'
 
 export function Filters({
   onSearch,
@@ -24,7 +24,7 @@ export function Filters({
   onReset: () => void
   isDoctor: boolean
 }) {
-  const { data: populatedFilters } = useGetPopulatedFiltersQuery()
+  const { data: populatedFilters } = useGetSickLeavesFiltersQuery()
   const { filter, sickLeaveLengthIntervals } = useAppSelector((state) => state.sickLeave)
   const dispatch = useDispatch()
 

--- a/apps/rehabstod/src/pages/CurrentSickLeaves/components/ModifySicknessTableColumns.tsx
+++ b/apps/rehabstod/src/pages/CurrentSickLeaves/components/ModifySicknessTableColumns.tsx
@@ -1,16 +1,16 @@
 import { useEffect } from 'react'
 import { ModifyTableColumns } from '../../../components/Table/ModifyTableColumns'
-import { useGetPopulatedFiltersQuery, useGetUserQuery } from '../../../store/api'
+import { filterTableColumns } from '../../../components/Table/utils/filterTableColumns'
+import { useGetSickLeavesFiltersQuery, useGetUserQuery } from '../../../store/api'
 import { useAppDispatch, useAppSelector, useUpdateUserPreferences } from '../../../store/hooks'
 import { allSickLeaveColumns, sickLeaveColumnsString } from '../../../store/slices/sickLeaveTableColumns.selector'
 import { hideColumn, moveColumn, setColumnDefaults, showAllColumns, showColumn } from '../../../store/slices/sickLeaveTableColumns.slice'
-import { filterTableColumns } from '../../../components/Table/utils/filterTableColumns'
 import { isUserDoctor } from '../../../utils/isUserDoctor'
 
 export function ModifySicknessTableColumns() {
   const dispatch = useAppDispatch()
   const { data: user } = useGetUserQuery()
-  const { data: populatedFilters } = useGetPopulatedFiltersQuery()
+  const { data: populatedFilters } = useGetSickLeavesFiltersQuery()
   const columns = useAppSelector(allSickLeaveColumns)
   const columnString = useAppSelector(sickLeaveColumnsString)
   const { updateUserPreferences } = useUpdateUserPreferences()

--- a/apps/rehabstod/src/pages/CurrentSickLeaves/components/TableBodyRows.tsx
+++ b/apps/rehabstod/src/pages/CurrentSickLeaves/components/TableBodyRows.tsx
@@ -3,23 +3,23 @@ import { useNavigate } from 'react-router-dom'
 import { DiagnosisDescription } from '../../../components/Diagnosis/DiagnosisDescription'
 import { DiagnosisInfo } from '../../../components/Diagnosis/DiagnosisInfo'
 import { EndDateInfo } from '../../../components/SickLeave/EndDateInfo'
+import { RekoStatusDropdown } from '../../../components/SickLeave/RekoStatusDropdown'
+import { RiskSignalInfo } from '../../../components/SickLeave/RiskSignalInfo'
 import { SickLeaveDegreeInfo } from '../../../components/SickLeave/SickLeaveDegreeInfo'
 import { useTableContext } from '../../../components/Table/hooks/useTableContext'
+import { MaxColspanRow } from '../../../components/Table/tableBody/MaxColspanRow'
 import { TableCell } from '../../../components/Table/tableBody/TableCell'
+import { TableRow } from '../../../components/Table/tableBody/TableRow'
+import { getEmptyFiltrationText, getEmptyTableText, getSearchText } from '../../../components/Table/utils/tableTextGeneratorUtils'
+import { getUnansweredCommunicationFormat } from '../../../components/UnansweredCommunication/utils/getUnansweredCommunicationFormat'
+import { User } from '../../../schemas'
 import { SickLeaveInfo } from '../../../schemas/sickLeaveSchema'
+import { useGetSickLeavesFiltersQuery } from '../../../store/api'
 import { useAppSelector } from '../../../store/hooks'
 import { allSickLeaveColumns } from '../../../store/slices/sickLeaveTableColumns.selector'
 import { SickLeaveColumn } from '../../../store/slices/sickLeaveTableColumns.slice'
 import { isDateBeforeToday } from '../../../utils/isDateBeforeToday'
 import { getSickLeavesColumnData } from '../utils/getSickLeavesColumnData'
-import { MaxColspanRow } from '../../../components/Table/tableBody/MaxColspanRow'
-import { RekoStatusDropdown } from '../../../components/SickLeave/RekoStatusDropdown'
-import { RiskSignalInfo } from '../../../components/SickLeave/RiskSignalInfo'
-import { useGetPopulatedFiltersQuery } from '../../../store/api'
-import { getUnansweredCommunicationFormat } from '../../../components/UnansweredCommunication/utils/getUnansweredCommunicationFormat'
-import { TableRow } from '../../../components/Table/tableBody/TableRow'
-import { getEmptyFiltrationText, getEmptyTableText, getSearchText } from '../../../components/Table/utils/tableTextGeneratorUtils'
-import { User } from '../../../schemas'
 
 function ResolveTableCell({ column, sickLeave, isDoctor }: { column: string; sickLeave: SickLeaveInfo; isDoctor: boolean }) {
   switch (column) {
@@ -99,7 +99,7 @@ export function TableBodyRows({
   const { sortTableList } = useTableContext()
   const columns = useAppSelector(allSickLeaveColumns)
   const { hasAppliedFilters } = useAppSelector((state) => state.sickLeave)
-  const { data: populatedFilters } = useGetPopulatedFiltersQuery()
+  const { data: populatedFilters } = useGetSickLeavesFiltersQuery()
 
   const TABLE_NAME = 'pågående sjukfall'
   const EMPTY_TEXT = getEmptyTableText(user, TABLE_NAME)

--- a/apps/rehabstod/src/pages/CurrentSickLeaves/components/TableHeaderRow.tsx
+++ b/apps/rehabstod/src/pages/CurrentSickLeaves/components/TableHeaderRow.tsx
@@ -1,5 +1,5 @@
 import { TableHeaderCell } from '../../../components/Table/tableHeader/TableHeaderCell'
-import { useGetPopulatedFiltersQuery, useGetUserQuery } from '../../../store/api'
+import { useGetSickLeavesFiltersQuery, useGetUserQuery } from '../../../store/api'
 import { useAppSelector } from '../../../store/hooks'
 import { allSickLeaveColumns } from '../../../store/slices/sickLeaveTableColumns.selector'
 import { SickLeaveColumn } from '../../../store/slices/sickLeaveTableColumns.slice'
@@ -93,7 +93,7 @@ function HeaderCellResolver({ column }: { column: string }) {
 
 export function TableHeaderRow({ showPersonalInformation, isDoctor }: { showPersonalInformation: boolean; isDoctor: boolean }) {
   const columns = useAppSelector(allSickLeaveColumns)
-  const { data: populatedFilters } = useGetPopulatedFiltersQuery()
+  const { data: populatedFilters } = useGetSickLeavesFiltersQuery()
 
   if (columns.length === 0) {
     return null

--- a/apps/rehabstod/src/pages/LUCertificates/LUCertificates.tsx
+++ b/apps/rehabstod/src/pages/LUCertificates/LUCertificates.tsx
@@ -9,7 +9,7 @@ import { TableHeadingForUnit } from '../../components/Table/heading/TableHeading
 import { TableHeader } from '../../components/Table/tableHeader/TableHeader'
 import { filterHiddenColumns, filterTableColumns } from '../../components/Table/utils/filterTableColumns'
 import { useNavigateToStartPage } from '../../hooks/useNavigateToStartPage'
-import { useGetPopulatedFiltersForLUQuery, useGetUserQuery, useLazyGetLUCertificatesQuery } from '../../store/api'
+import { useGetLUFiltersQuery, useGetUserQuery, useLazyGetLUCertificatesQuery } from '../../store/api'
 import { useAppSelector } from '../../store/hooks'
 import { reset } from '../../store/slices/luCertificates.slice'
 import { allLuCertificatesColumns } from '../../store/slices/luCertificatesTableColumns.selector'
@@ -30,7 +30,7 @@ export function LUCertificates() {
     sortColumn: LUCertificatesColumn.Signeringsdatum,
     ascending: false,
   })
-  const { data: populatedFilters } = useGetPopulatedFiltersForLUQuery()
+  const { data: populatedFilters } = useGetLUFiltersQuery()
   const { hasAppliedFilters } = useAppSelector((state) => state.luCertificates)
   const { showPersonalInformation } = useAppSelector((state) => state.settings)
 

--- a/apps/rehabstod/src/pages/LUCertificates/LUCertificatesFilters.tsx
+++ b/apps/rehabstod/src/pages/LUCertificates/LUCertificatesFilters.tsx
@@ -1,25 +1,25 @@
-import { useDispatch } from 'react-redux'
 import { useState } from 'react'
+import { useDispatch } from 'react-redux'
 import { TableFilter } from '../../components/Table/TableFilter'
-import { RangeFilter } from '../../components/Table/filter/RangeFilter'
-import { useAppSelector } from '../../store/hooks'
-import { TextSearchFilter } from '../../components/Table/filter/TextSearchFilter'
-import { SelectFilter } from '../../components/Table/filter/SelectFilter'
-import { getMultipleSelectPlaceholder } from '../../components/Table/filter/utils/getMultipleSelectPlaceholder'
-import { MultipleSelectFilterOption } from '../../components/Table/filter/MultipleSelectFilterOption'
-import { resetFilters, updateFilter } from '../../store/slices/luCertificates.slice'
-import { useGetPopulatedFiltersForLUQuery, useGetUserQuery } from '../../store/api'
-import { DoctorFilter } from '../../components/Table/filter/DoctorFilter'
-import { DiagnosisFilter } from '../../components/Table/filter/DiagnosisFilter'
-import { DiagnosKapitel } from '../../schemas/diagnosisSchema'
-import { isUserDoctor } from '../../utils/isUserDoctor'
 import { DateRangeFilter } from '../../components/Table/filter/DateRangeFilter'
+import { DiagnosisFilter } from '../../components/Table/filter/DiagnosisFilter'
+import { DoctorFilter } from '../../components/Table/filter/DoctorFilter'
+import { MultipleSelectFilterOption } from '../../components/Table/filter/MultipleSelectFilterOption'
+import { RangeFilter } from '../../components/Table/filter/RangeFilter'
+import { SelectFilter } from '../../components/Table/filter/SelectFilter'
+import { TextSearchFilter } from '../../components/Table/filter/TextSearchFilter'
+import { getMultipleSelectPlaceholder } from '../../components/Table/filter/utils/getMultipleSelectPlaceholder'
+import { DiagnosKapitel } from '../../schemas/diagnosisSchema'
 import { LUCertificatesFilter } from '../../schemas/luCertificatesSchema'
+import { useGetLUFiltersQuery, useGetUserQuery } from '../../store/api'
+import { useAppSelector } from '../../store/hooks'
+import { resetFilters, updateFilter } from '../../store/slices/luCertificates.slice'
+import { isUserDoctor } from '../../utils/isUserDoctor'
 
 export function LUCertificatesFilters({ onSearch }: { onSearch: (filter: LUCertificatesFilter) => void }) {
   const { filter, unansweredCommunicationFilterTypes, certificateFilterTypes } = useAppSelector((state) => state.luCertificates)
 
-  const { data: populatedFilters } = useGetPopulatedFiltersForLUQuery()
+  const { data: populatedFilters } = useGetLUFiltersQuery()
   const { data: user } = useGetUserQuery()
 
   const [selectedDiagnosisChapters, setSelectedDiagnosisChapters] = useState<DiagnosKapitel[]>([])

--- a/apps/rehabstod/src/pages/Patient/Patient.tsx
+++ b/apps/rehabstod/src/pages/Patient/Patient.tsx
@@ -1,19 +1,19 @@
-import { useLocation, useParams } from 'react-router-dom'
 import { skipToken } from '@reduxjs/toolkit/query'
-import { PatientTabs } from './components/PatientTabs'
-import { PatientHeader } from './components/PatientHeader'
-import { PatientErrorHeader } from './components/PatientErrorHeader'
-import { OpenTabsDialog } from './components/OpenTabsDialog'
-import { PatientContext, usePatientState } from './hooks/usePatient'
-import { useGetSickLeavePatientQuery } from '../../store/api'
+import { useLocation, useParams } from 'react-router-dom'
 import { PageContainer } from '../../components/PageContainer/PageContainer'
+import { useGetPatientSickLeavesQuery } from '../../store/api'
+import { OpenTabsDialog } from './components/OpenTabsDialog'
+import { PatientErrorHeader } from './components/PatientErrorHeader'
+import { PatientHeader } from './components/PatientHeader'
+import { PatientTabs } from './components/PatientTabs'
+import { PatientContext, usePatientState } from './hooks/usePatient'
 
 export function Patient() {
   const patientState = usePatientState()
   const { encryptedPatientId } = useParams()
   const { state } = useLocation()
 
-  const { data: patient } = useGetSickLeavePatientQuery(
+  const { data: patient } = useGetPatientSickLeavesQuery(
     encryptedPatientId
       ? {
           encryptedPatientId,

--- a/apps/rehabstod/src/pages/Patient/components/PatientRekoStatus.tsx
+++ b/apps/rehabstod/src/pages/Patient/components/PatientRekoStatus.tsx
@@ -1,7 +1,7 @@
 import { useLocation } from 'react-router-dom'
 import { SelectRekoStatus } from '../../../components/SelectRekoStatus/SelectRekoStatus'
-import { useGetPopulatedFiltersQuery } from '../../../store/api'
 import { PatientSjukfall } from '../../../schemas/patientSchema'
+import { useGetSickLeavesFiltersQuery } from '../../../store/api'
 
 export function PatientRekoStatus({
   currentSickLeaves,
@@ -10,7 +10,7 @@ export function PatientRekoStatus({
   currentSickLeaves: PatientSjukfall[]
   earlierSickLeaves: PatientSjukfall[]
 }) {
-  const { data: populatedFilters } = useGetPopulatedFiltersQuery()
+  const { data: populatedFilters } = useGetSickLeavesFiltersQuery()
   const { state } = useLocation()
   const getCertificateToSaveRekoStatusOn = () => {
     if (currentSickLeaves && currentSickLeaves.length > 0) {

--- a/apps/rehabstod/src/pages/Patient/components/patientLU/PatientLUCertificatesTable.tsx
+++ b/apps/rehabstod/src/pages/Patient/components/patientLU/PatientLUCertificatesTable.tsx
@@ -1,19 +1,19 @@
 import { useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { TableHeader } from '../../../../components/Table/tableHeader/TableHeader'
-import { getLUCertificatesColumnInfo } from '../../../LUCertificates/utils/getLUCertificatesColumnsInfo'
-import { LUCertificatesTableBody } from '../../../LUCertificates/LUCertificatesTableBody'
+import { EmptyPatientTableMessage } from '../../../../components/Table/EmptyPatientTableMessage'
 import { Table } from '../../../../components/Table/Table'
-import { LUCertificatesColumn } from '../../../../store/slices/luCertificatesTableColumns.slice'
+import { TableHeadingForUnit } from '../../../../components/Table/heading/TableHeadingForUnit'
+import { TableHeader } from '../../../../components/Table/tableHeader/TableHeader'
+import { filterHiddenColumns, filterTableColumn, filterTableColumns } from '../../../../components/Table/utils/filterTableColumns'
+import { PatientTableError } from '../../../../components/error/ErrorAlert/PatientTableError'
+import { useGetPatientLUCertificatesQuery, useGetUserQuery } from '../../../../store/api'
 import { useAppSelector } from '../../../../store/hooks'
 import { allLuCertificatesColumns } from '../../../../store/slices/luCertificatesTableColumns.selector'
-import { useGetLUCertificatesForPatientQuery, useGetUserQuery } from '../../../../store/api'
+import { LUCertificatesColumn } from '../../../../store/slices/luCertificatesTableColumns.slice'
 import { isUserDoctor } from '../../../../utils/isUserDoctor'
-import { filterHiddenColumns, filterTableColumn, filterTableColumns } from '../../../../components/Table/utils/filterTableColumns'
-import { TableHeadingForUnit } from '../../../../components/Table/heading/TableHeadingForUnit'
+import { LUCertificatesTableBody } from '../../../LUCertificates/LUCertificatesTableBody'
 import { ModifyLUCertificatesTableColumns } from '../../../LUCertificates/ModifyLUCertificatesTableColumns'
-import { PatientTableError } from '../../../../components/error/ErrorAlert/PatientTableError'
-import { EmptyPatientTableMessage } from '../../../../components/Table/EmptyPatientTableMessage'
+import { getLUCertificatesColumnInfo } from '../../../LUCertificates/utils/getLUCertificatesColumnsInfo'
 
 export function PatientLUCertificatesTable() {
   const { data: user } = useGetUserQuery()
@@ -27,7 +27,7 @@ export function PatientLUCertificatesTable() {
   const isDoctor = user ? isUserDoctor(user) : false
   const filteredColumns = filterTableColumns(allColumns, isDoctor, showPersonalInformation, false, undefined, undefined, true)
   const visibleColumns = filterHiddenColumns(filteredColumns)
-  const { data: luCertificatesInfo, error: getLuCertificatesError } = useGetLUCertificatesForPatientQuery({
+  const { data: luCertificatesInfo, error: getLuCertificatesError } = useGetPatientLUCertificatesQuery({
     encryptedPatientId: encryptedPatientId || '',
   })
 

--- a/apps/rehabstod/src/pages/Patient/components/patientSickLeaves/ModifyPatientTableColumns.tsx
+++ b/apps/rehabstod/src/pages/Patient/components/patientSickLeaves/ModifyPatientTableColumns.tsx
@@ -1,4 +1,9 @@
 import { useEffect } from 'react'
+import { ModifyTableColumns } from '../../../../components/Table/ModifyTableColumns'
+import { filterTableColumns } from '../../../../components/Table/utils/filterTableColumns'
+import { useGetSickLeavesFiltersQuery, useGetUserQuery } from '../../../../store/api'
+import { useAppDispatch, useAppSelector, useUpdateUserPreferences } from '../../../../store/hooks'
+import { allPatientColumns, patientColumnsString } from '../../../../store/slices/patientTableColumns.selector'
 import {
   hideColumn,
   moveColumn,
@@ -7,12 +12,7 @@ import {
   showAllColumns,
   showColumn,
 } from '../../../../store/slices/patientTableColumns.slice'
-import { useAppDispatch, useAppSelector, useUpdateUserPreferences } from '../../../../store/hooks'
-import { useGetPopulatedFiltersQuery, useGetUserQuery } from '../../../../store/api'
-import { allPatientColumns, patientColumnsString } from '../../../../store/slices/patientTableColumns.selector'
-import { ModifyTableColumns } from '../../../../components/Table/ModifyTableColumns'
 import { isUserDoctor } from '../../../../utils/isUserDoctor'
-import { filterTableColumns } from '../../../../components/Table/utils/filterTableColumns'
 
 export function ModifyPatientTableColumns() {
   const dispatch = useAppDispatch()
@@ -20,7 +20,7 @@ export function ModifyPatientTableColumns() {
   const columns = useAppSelector(allPatientColumns)
   const columnString = useAppSelector(patientColumnsString)
   const { updateUserPreferences } = useUpdateUserPreferences()
-  const { data: populatedFilters } = useGetPopulatedFiltersQuery()
+  const { data: populatedFilters } = useGetSickLeavesFiltersQuery()
 
   useEffect(() => {
     if (user && columnString !== user.preferences.patientTableColumns) {

--- a/apps/rehabstod/src/pages/Patient/components/patientSickLeaves/PatientSickLeaves.tsx
+++ b/apps/rehabstod/src/pages/Patient/components/patientSickLeaves/PatientSickLeaves.tsx
@@ -1,21 +1,21 @@
 import { skipToken } from '@reduxjs/toolkit/query'
 import { useParams } from 'react-router-dom'
-import { useGetSickLeavePatientQuery, useGetUserQuery } from '../../../../store/api'
-import { isDateBeforeToday } from '../../../../utils/isDateBeforeToday'
+import { PageContainer } from '../../../../components/PageContainer/PageContainer'
 import { TableHeadingForUnit } from '../../../../components/Table/heading/TableHeadingForUnit'
+import { PatientTableError } from '../../../../components/error/ErrorAlert/PatientTableError'
 import { UserUrval } from '../../../../schemas'
+import { PuResponse } from '../../../../schemas/patientSchema'
+import { useGetPatientSickLeavesQuery, useGetUserQuery } from '../../../../store/api'
+import { isDateBeforeToday } from '../../../../utils/isDateBeforeToday'
+import { PatientRekoStatus } from '../PatientRekoStatus'
+import { PatientOverview } from '../patientOverview/PatientOverview'
 import { ModifyPatientTableColumns } from './ModifyPatientTableColumns'
 import { PatientSickLeavesTable } from './PatientSickLeavesTable'
-import { PatientOverview } from '../patientOverview/PatientOverview'
-import { PuResponse } from '../../../../schemas/patientSchema'
-import { PatientTableError } from '../../../../components/error/ErrorAlert/PatientTableError'
-import { PageContainer } from '../../../../components/PageContainer/PageContainer'
-import { PatientRekoStatus } from '../PatientRekoStatus'
 
 export function PatientSickLeaves() {
   const { encryptedPatientId } = useParams()
   const { data: user } = useGetUserQuery()
-  const { data: patient, error } = useGetSickLeavePatientQuery(
+  const { data: patient, error } = useGetPatientSickLeavesQuery(
     encryptedPatientId
       ? {
           encryptedPatientId,

--- a/apps/rehabstod/src/store/api.ts
+++ b/apps/rehabstod/src/store/api.ts
@@ -97,7 +97,6 @@ export const api = createApi({
         url: 'sickleaves/active',
         method: 'POST',
         body: request,
-        providesTags: ['SickLeaves'],
       }),
       providesTags: ['User'],
     }),

--- a/apps/rehabstod/src/store/api.ts
+++ b/apps/rehabstod/src/store/api.ts
@@ -1,8 +1,10 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import { Link, Mottagning, Ping, User, UserPreferences, Vardenhet } from '../schemas'
 import { Config } from '../schemas/configSchema'
+import { DiagnosKapitel } from '../schemas/diagnosisSchema'
 import { ErrorData } from '../schemas/errorSchema'
 import { Lakare } from '../schemas/lakareSchema'
+import { LUCertificatesFilter, LUCertificatesInfo } from '../schemas/luCertificatesSchema'
 import { Patient } from '../schemas/patientSchema'
 import {
   OccupationType,
@@ -14,8 +16,6 @@ import {
 } from '../schemas/sickLeaveSchema'
 import { CreateSickleaveDTO, TestDataOptionsDTO } from '../schemas/testabilitySchema'
 import { getCookie } from '../utils/cookies'
-import { DiagnosKapitel } from '../schemas/diagnosisSchema'
-import { LUCertificatesFilter, LUCertificatesInfo } from '../schemas/luCertificatesSchema'
 
 export const api = createApi({
   reducerPath: 'api',
@@ -28,7 +28,7 @@ export const api = createApi({
       return headers
     },
   }),
-  tagTypes: ['User', 'SickLeavesFilter', 'SickLeaveSummary', 'SickLeaves', 'SickLeavePatient', 'LUCertificates', 'LUCertificatesPatient'],
+  tagTypes: ['User', 'Patient'],
   endpoints: (builder) => ({
     getUser: builder.query<User, void>({
       query: () => 'user',
@@ -43,7 +43,7 @@ export const api = createApi({
         method: 'POST',
         body: { id: vardenhet.id },
       }),
-      invalidatesTags: ['SickLeavesFilter', 'SickLeaveSummary', 'User'],
+      invalidatesTags: ['User'],
       async onQueryStarted({ vardenhet }, { dispatch, queryFulfilled }) {
         dispatch(
           api.util.updateQueryData('getUser', undefined, (draft) =>
@@ -99,7 +99,7 @@ export const api = createApi({
         body: request,
         providesTags: ['SickLeaves'],
       }),
-      providesTags: ['SickLeaves'],
+      providesTags: ['User'],
     }),
     getLUCertificates: builder.query<LUCertificatesInfo, LUCertificatesFilter>({
       query: (request) => ({
@@ -107,7 +107,6 @@ export const api = createApi({
         method: 'POST',
         body: request,
       }),
-      providesTags: ['LUCertificates'],
     }),
     getPopulatedFilters: builder.query<
       {
@@ -125,7 +124,7 @@ export const api = createApi({
       query: () => ({
         url: 'sickleaves/filters',
       }),
-      providesTags: ['SickLeavesFilter'],
+      providesTags: ['User'],
     }),
     getPopulatedFiltersForLU: builder.query<
       {
@@ -141,7 +140,7 @@ export const api = createApi({
       query: () => ({
         url: 'sickleaves/summary',
       }),
-      providesTags: ['SickLeaveSummary'],
+      providesTags: ['User'],
     }),
     getSickLeavePatient: builder.query<Patient, { encryptedPatientId: string }>({
       keepUnusedDataFor: 0,
@@ -150,7 +149,7 @@ export const api = createApi({
         method: 'POST',
         body: encryptedPatientId,
       }),
-      providesTags: ['SickLeavePatient'],
+      providesTags: ['Patient'],
     }),
     getLUCertificatesForPatient: builder.query<LUCertificatesInfo, { encryptedPatientId: string }>({
       query: (request) => ({
@@ -158,7 +157,6 @@ export const api = createApi({
         method: 'POST',
         body: request,
       }),
-      providesTags: ['LUCertificatesPatient'],
     }),
     createDefaultTestData: builder.mutation<string, void>({
       query: () => ({
@@ -187,7 +185,7 @@ export const api = createApi({
         method: 'POST',
         body: { patientId, vardenhetId },
       }),
-      invalidatesTags: ['SickLeavePatient'],
+      invalidatesTags: ['Patient'],
     }),
     addVardgivare: builder.mutation<string[], { patientId: string; vardgivareId: string }>({
       query: ({ patientId, vardgivareId }) => ({
@@ -195,7 +193,7 @@ export const api = createApi({
         method: 'POST',
         body: { patientId, vardgivareId },
       }),
-      invalidatesTags: ['SickLeavePatient'],
+      invalidatesTags: ['Patient'],
     }),
     giveSjfConsent: builder.mutation<
       { registeredBy: string; responseCode: string; responseMessage: string },
@@ -222,7 +220,7 @@ export const api = createApi({
             )
           )
         } catch {
-          dispatch(api.util.invalidateTags(['SickLeavePatient']))
+          dispatch(api.util.invalidateTags(['Patient']))
         }
       },
     }),

--- a/apps/rehabstod/src/store/api.ts
+++ b/apps/rehabstod/src/store/api.ts
@@ -28,7 +28,7 @@ export const api = createApi({
       return headers
     },
   }),
-  tagTypes: ['User', 'Patient'],
+  tagTypes: ['User', 'Patient', 'SickLeaves'],
   endpoints: (builder) => ({
     getUser: builder.query<User, void>({
       query: () => 'user',
@@ -100,14 +100,7 @@ export const api = createApi({
       }),
       providesTags: ['User'],
     }),
-    getLUCertificates: builder.query<LUCertificatesInfo, LUCertificatesFilter>({
-      query: (request) => ({
-        url: 'certificate/lu/unit',
-        method: 'POST',
-        body: request,
-      }),
-    }),
-    getPopulatedFilters: builder.query<
+    getSickLeavesFilters: builder.query<
       {
         activeDoctors: Lakare[]
         allDiagnosisChapters: DiagnosKapitel[]
@@ -123,9 +116,31 @@ export const api = createApi({
       query: () => ({
         url: 'sickleaves/filters',
       }),
-      providesTags: ['User'],
+      providesTags: ['User', 'SickLeaves'],
     }),
-    getPopulatedFiltersForLU: builder.query<
+    getSickLeavesSummary: builder.query<SickLeaveSummary, void>({
+      query: () => ({
+        url: 'sickleaves/summary',
+      }),
+      providesTags: ['User', 'SickLeaves'],
+    }),
+    getPatientSickLeaves: builder.query<Patient, { encryptedPatientId: string }>({
+      keepUnusedDataFor: 0,
+      query: (encryptedPatientId) => ({
+        url: 'sjukfall/patient',
+        method: 'POST',
+        body: encryptedPatientId,
+      }),
+      providesTags: ['Patient', 'SickLeaves'],
+    }),
+    getLUCertificates: builder.query<LUCertificatesInfo, LUCertificatesFilter>({
+      query: (request) => ({
+        url: 'certificate/lu/unit',
+        method: 'POST',
+        body: request,
+      }),
+    }),
+    getLUFilters: builder.query<
       {
         doctors: Lakare[]
         allDiagnosisChapters: DiagnosKapitel[]
@@ -135,26 +150,17 @@ export const api = createApi({
       keepUnusedDataFor: 0,
       query: () => 'lu/filters',
     }),
-    getSickLeavesSummary: builder.query<SickLeaveSummary, void>({
-      query: () => ({
-        url: 'sickleaves/summary',
-      }),
-      providesTags: ['User'],
-    }),
-    getSickLeavePatient: builder.query<Patient, { encryptedPatientId: string }>({
-      keepUnusedDataFor: 0,
-      query: (encryptedPatientId) => ({
-        url: 'sjukfall/patient',
-        method: 'POST',
-        body: encryptedPatientId,
-      }),
-      providesTags: ['Patient'],
-    }),
-    getLUCertificatesForPatient: builder.query<LUCertificatesInfo, { encryptedPatientId: string }>({
+    getPatientLUCertificates: builder.query<LUCertificatesInfo, { encryptedPatientId: string }>({
       query: (request) => ({
         url: 'certificate/lu/person',
         method: 'POST',
         body: request,
+      }),
+    }),
+    getLUCertificatesDoctors: builder.query<{ doctors: Lakare[] }, void>({
+      query: () => ({
+        url: 'certificate/lu/doctors',
+        method: 'GET',
       }),
     }),
     createDefaultTestData: builder.mutation<string, void>({
@@ -209,7 +215,7 @@ export const api = createApi({
             data: { responseCode },
           } = await queryFulfilled
           dispatch(
-            api.util.updateQueryData('getSickLeavePatient', { encryptedPatientId }, (draft) =>
+            api.util.updateQueryData('getPatientSickLeaves', { encryptedPatientId }, (draft) =>
               Object.assign(draft, {
                 sjfMetaData: {
                   ...(draft.sjfMetaData ?? {}),
@@ -256,12 +262,6 @@ export const api = createApi({
         body: errorData,
       }),
     }),
-    getDoctorsForLUCertificates: builder.query<{ doctors: Lakare[] }, void>({
-      query: () => ({
-        url: 'certificate/lu/doctors',
-        method: 'GET',
-      }),
-    }),
   }),
 })
 
@@ -273,22 +273,22 @@ export const {
   useCreateSickLeaveMutation,
   useFakeLogoutMutation,
   useGetConfigQuery,
+  useGetLUCertificatesDoctorsQuery,
   useGetLinksQuery,
-  useGetPopulatedFiltersQuery,
+  useGetLUFiltersQuery,
+  useGetPatientLUCertificatesQuery,
   useGetSessionPingQuery,
-  useGetSickLeavePatientQuery,
-  useGetLUCertificatesForPatientQuery,
+  useGetPatientSickLeavesQuery,
+  useGetSickLeavesFiltersQuery,
   useGetSickLeavesQuery,
   useGetSickLeavesSummaryQuery,
   useGetTestDataOptionsQuery,
   useGetUserQuery,
   useGiveConsentMutation,
   useGiveSjfConsentMutation,
+  useLazyGetLUCertificatesQuery,
   useLazyGetSickLeavesQuery,
   useLogErrorMutation,
-  useLazyGetLUCertificatesQuery,
   useSetRekoStatusMutation,
   useUpdateUserPreferencesMutation,
-  useGetDoctorsForLUCertificatesQuery,
-  useGetPopulatedFiltersForLUQuery,
 } = api

--- a/apps/rehabstod/src/store/hooks.ts
+++ b/apps/rehabstod/src/store/hooks.ts
@@ -30,7 +30,7 @@ export function useUpdateUserPreferences() {
                 ['maxAntalDagarSedanSjukfallAvslut', 'standardenhet', 'maxAntalDagarMellanIntyg'].includes(key)
               )
             ) {
-              dispatch(api.util.invalidateTags(['SickLeaveSummary', 'SickLeavesFilter', 'SickLeaves', 'SickLeavePatient']))
+              dispatch(api.util.invalidateTags(['SickLeaves', 'Patient']))
             }
             return data
           })


### PR DESCRIPTION
Instead of having unique tags per endpoint, we can have common tags that get invalidated for multiple endpoints. For example, if we have endpoints that need to be invalidated when the user settings get updated, we can simply tag them together with "User".