### PR TITLE
INTYGFV-16000: Login issues

### DIFF
--- a/apps/minaintyg/src/components/ProtectedRoute/ProtectedRoute.test.tsx
+++ b/apps/minaintyg/src/components/ProtectedRoute/ProtectedRoute.test.tsx
@@ -5,15 +5,24 @@ import { server } from '../../mocks/server'
 import { store } from '../../store/store'
 import { ProtectedRoute } from './ProtectedRoute'
 
-it('Should render children when user is available', async () => {
-  render(
+function renderComponent() {
+  return render(
     <Provider store={store}>
       <ProtectedRoute>
         <p>content</p>
       </ProtectedRoute>
     </Provider>
   )
+}
 
+it('Should not render children while loading', async () => {
+  const { container } = renderComponent()
+
+  expect(container).toBeEmptyDOMElement()
+})
+
+it('Should render children when user is available', async () => {
+  renderComponent()
   expect(await screen.findByText('content')).toBeInTheDocument()
 })
 
@@ -21,13 +30,7 @@ it('Should redirect to saml login when unable to load user', async () => {
   server.use(rest.get('/api/user', (_, res, ctx) => res(ctx.status(401))))
   const openSpy = vi.spyOn(window, 'open')
 
-  render(
-    <Provider store={store}>
-      <ProtectedRoute>
-        <p>content</p>
-      </ProtectedRoute>
-    </Provider>
-  )
+  renderComponent()
 
   await waitFor(() => {
     expect(openSpy).toHaveBeenCalledWith('/saml2/authenticate/eleg', '_self')

--- a/apps/minaintyg/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/apps/minaintyg/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -2,10 +2,18 @@ import { ReactNode } from 'react'
 import { useGetUserQuery } from '../../store/api'
 
 export function ProtectedRoute({ children }: { children: ReactNode }): JSX.Element | null {
-  const { isError } = useGetUserQuery()
+  const { isError, isLoading } = useGetUserQuery()
+
+  if (isLoading) {
+    return null
+  }
 
   if (isError) {
-    window.open('/saml2/authenticate/eleg', '_self')
+    if (import.meta.env.MODE === 'development') {
+      window.open('/welcome', '_self')
+    } else {
+      window.open('/saml2/authenticate/eleg', '_self')
+    }
     return null
   }
 

--- a/apps/minaintyg/src/pages/Welcome/components/FakeLoginForm.tsx
+++ b/apps/minaintyg/src/pages/Welcome/components/FakeLoginForm.tsx
@@ -1,4 +1,4 @@
-import { IDSButton } from '@frontend/ids-react-ts'
+import { IDSButton, IDSButtonGroup } from '@frontend/ids-react-ts'
 import { tryCatch } from '@frontend/utils'
 import { useEffect, useState } from 'react'
 import { TestabilityPerson } from '../../../schema/testability/person.schema'
@@ -44,17 +44,22 @@ export function FakeLoginForm({ persons }: { persons: TestabilityPerson[] }) {
           />
         </div>
       </div>
-      <IDSButton
-        type="submit"
-        disabled={!profile}
-        onClick={() => {
-          if (profile) {
-            login({ personId: profile })
-          }
-        }}
-      >
-        Logga in
-      </IDSButton>
+      <IDSButtonGroup>
+        <IDSButton secondary onClick={() => window.open('/saml2/authenticate/eleg', '_self')}>
+          SAML Login
+        </IDSButton>
+        <IDSButton
+          type="submit"
+          disabled={!profile}
+          onClick={() => {
+            if (profile) {
+              login({ personId: profile })
+            }
+          }}
+        >
+          Logga in
+        </IDSButton>
+      </IDSButtonGroup>
     </div>
   )
 }

--- a/apps/minaintyg/src/router.tsx
+++ b/apps/minaintyg/src/router.tsx
@@ -10,25 +10,18 @@ import { Welcome } from './pages/Welcome/Welcome'
 
 export const router = createBrowserRouter(
   createRoutesFromChildren([
-    <Route key="root" path="/" handle={{ crumb: () => 'Start' }} element={<Layout />}>
-      <Route
-        index
-        element={
-          <ProtectedRoute>
-            <Home />
-          </ProtectedRoute>
-        }
-      />
-
-      <Route
-        path="/intyg"
-        handle={{ crumb: () => 'Intyg' }}
-        element={
-          <ProtectedRoute>
-            <Outlet />
-          </ProtectedRoute>
-        }
-      >
+    <Route
+      key="root"
+      path="/"
+      handle={{ crumb: () => 'Start' }}
+      element={
+        <ProtectedRoute>
+          <Layout />
+        </ProtectedRoute>
+      }
+    >
+      <Route index element={<Home />} />
+      <Route path="/intyg" handle={{ crumb: () => 'Intyg' }} element={<Outlet />}>
         <Route index element={<CertificateListPage />} />
         <Route
           path=":id"

--- a/apps/minaintyg/src/store/testabilityApi.ts
+++ b/apps/minaintyg/src/store/testabilityApi.ts
@@ -11,7 +11,7 @@ const testabilityApi = api.injectEndpoints({
       }),
       async onQueryStarted(_, { queryFulfilled }) {
         await queryFulfilled
-        window.location.assign('/')
+        window.location.assign('/intyg')
       },
     }),
     fakeLogout: builder.mutation<void, void>({


### PR DESCRIPTION
* Should not render children while loading user in `ProtectedRoute`
* Redirect to `/welcome` when in development mode and not logged in
* Added button from `/welcome` to activate SAML login
* Navigate to `/intyg` when using fake-login