### PR TITLE
INTYGFV-16019 & INTYGFV-16021 & INTYGFV-16020: Design touchups

### DIFF
--- a/apps/minaintyg/src/components/FilterAccordion/FilterAccordion.test.tsx
+++ b/apps/minaintyg/src/components/FilterAccordion/FilterAccordion.test.tsx
@@ -16,5 +16,5 @@ it('Should render as expected', () => {
 
 it('Should render label', () => {
   renderComponent()
-  expect(screen.getByText(`43 av 100 intyg`)).toBeInTheDocument()
+  expect(screen.getByText(`Visar 43 av 100 intyg`)).toBeInTheDocument()
 })

--- a/apps/minaintyg/src/components/FilterAccordion/FilterAccordion.tsx
+++ b/apps/minaintyg/src/components/FilterAccordion/FilterAccordion.tsx
@@ -6,7 +6,7 @@ export function FilterAccordion({ total, listed, noun, children }: { noun: strin
     <details className="group mb-5">
       <summary className="flex cursor-pointer select-none flex-col md:flex-row">
         <div className="grow border-y border-stone-clear py-2.5 md:pl-5">
-          {listed} av {total} {noun}
+          Visar {listed} av {total} {noun}
         </div>
         <div className="-mt-px flex justify-between gap-5 border-y border-stone-clear py-2.5 md:mt-0 md:border-l md:px-5">
           Filtrera lista

--- a/apps/minaintyg/src/components/FilterAccordion/__snapshots__/FilterAccordion.test.tsx.snap
+++ b/apps/minaintyg/src/components/FilterAccordion/__snapshots__/FilterAccordion.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`Should render as expected 1`] = `
       <div
         class="grow border-y border-stone-clear py-2.5 md:pl-5"
       >
+        Visar 
         43
          av 
         100

--- a/apps/minaintyg/src/components/Layout/ScrollTopButton.tsx
+++ b/apps/minaintyg/src/components/Layout/ScrollTopButton.tsx
@@ -7,7 +7,7 @@ export function ScrollTopButton() {
 
   useEffect(() => {
     const handleScroll = () => {
-      setShow(document.body.getBoundingClientRect().top < -360)
+      setShow(document.body.getBoundingClientRect().top < -180)
     }
 
     window.addEventListener('scroll', handleScroll, true)

--- a/apps/minaintyg/src/components/PageDivider/PageDivider.test.tsx
+++ b/apps/minaintyg/src/components/PageDivider/PageDivider.test.tsx
@@ -6,7 +6,7 @@ it('Should render as expected', () => {
   expect(container).toMatchInlineSnapshot(`
     <div>
       <hr
-        class="my-7 border-stone-clear"
+        class="my-7 border-stone-line"
       />
     </div>
   `)

--- a/apps/minaintyg/src/components/PageDivider/PageDivider.tsx
+++ b/apps/minaintyg/src/components/PageDivider/PageDivider.tsx
@@ -1,3 +1,3 @@
 export function PageDivider() {
-  return <hr className="my-7 border-stone-clear" />
+  return <hr className="my-7 border-stone-line" />
 }

--- a/apps/minaintyg/src/components/PageHeading/PageHeading.tsx
+++ b/apps/minaintyg/src/components/PageHeading/PageHeading.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react'
 export function PageHeading({ heading, children }: { heading?: string; children?: ReactNode }) {
   return (
     <header className="ids-content mb-7">
-      {heading && <h1 className="ids-heading-1 text-[min(2.25rem,9.25vw)]/[min(2.25rem,9.25vw)] md:text-5xl">{heading}</h1>}
+      {heading && <h1 className="ids-heading-1">{heading}</h1>}
       {children}
     </header>
   )

--- a/apps/minaintyg/src/components/PageHeading/__snapshots__/PageHeading.test.tsx.snap
+++ b/apps/minaintyg/src/components/PageHeading/__snapshots__/PageHeading.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Should render correctly 1`] = `
     class="ids-content mb-7"
   >
     <h1
-      class="ids-heading-1 text-[min(2.25rem,9.25vw)]/[min(2.25rem,9.25vw)] md:text-5xl"
+      class="ids-heading-1"
     >
       Test
     </h1>

--- a/apps/minaintyg/src/index.css
+++ b/apps/minaintyg/src/index.css
@@ -111,6 +111,6 @@ a:hover {
   border-top: 0;
 }
 
-.ids table.ids-table tbody tr:last-child th + td {
+.ids table.ids-table tbody tr:last-child th + td:last-child {
   border-bottom: 0;
 }

--- a/apps/minaintyg/src/index.css
+++ b/apps/minaintyg/src/index.css
@@ -107,10 +107,10 @@ a:hover {
   border-radius: 10px 0 0 10px;
 }
 
-.ids table.ids-table tbody:first-child tr:first-child th + td {
+.ids table.ids-table tbody:first-child tr:first-child th ~ td {
   border-top: 0;
 }
 
-.ids table.ids-table tbody tr:last-child th + td:last-child {
+.ids table.ids-table tbody tr:last-child th ~ td {
   border-bottom: 0;
 }

--- a/apps/minaintyg/src/index.css
+++ b/apps/minaintyg/src/index.css
@@ -65,3 +65,52 @@ a {
 a:hover {
   color: var(--color-sky-dark);
 }
+
+.ids table.ids-table {
+  border-bottom: 0;
+  border-radius: 0;
+}
+
+.ids table.ids-table tbody tr:last-child td {
+  border-bottom: var(--table_border-bottom);
+}
+
+.ids table.ids-table tbody tr:last-child th {
+  border-bottom: 0;
+}
+
+.ids table.ids-table tbody:not(:first-child) tr:first-child th {
+  border-top: var(--table-cell_border);
+}
+
+.ids table.ids-table thead th:first-child {
+  border-radius: 10px 0 0 0;
+}
+
+.ids table.ids-table thead th:last-child {
+  border-radius: 0 10px 0 0;
+}
+
+.ids table.ids-table thead th:last-child:first-child {
+  border-radius: 10px 10px 0 0;
+}
+
+.ids table.ids-table tbody:first-child tr:first-child th {
+  border-radius: 10px 0 0 0;
+}
+
+.ids table.ids-table tbody tr:last-child th {
+  border-radius: 0 0 0 10px;
+}
+
+.ids table.ids-table tbody:first-child tr:last-child:first-child th {
+  border-radius: 10px 0 0 10px;
+}
+
+.ids table.ids-table tbody:first-child tr:first-child th + td {
+  border-top: 0;
+}
+
+.ids table.ids-table tbody tr:last-child th + td {
+  border-bottom: 0;
+}

--- a/apps/minaintyg/src/index.css
+++ b/apps/minaintyg/src/index.css
@@ -56,3 +56,12 @@ ids-header-avatar a {
   color: rgb(160, 11, 54) !important;
   text-decoration: underline !important;
 }
+
+a {
+  color: var(--color-sky-base);
+  text-decoration: underline;
+}
+
+a:hover {
+  color: var(--color-sky-dark);
+}

--- a/apps/minaintyg/src/index.css
+++ b/apps/minaintyg/src/index.css
@@ -75,10 +75,6 @@ a:hover {
   border-bottom: var(--table_border-bottom);
 }
 
-.ids table.ids-table tbody tr:last-child th {
-  border-bottom: 0;
-}
-
 .ids table.ids-table tbody:not(:first-child) tr:first-child th {
   border-top: var(--table-cell_border);
 }
@@ -100,6 +96,7 @@ a:hover {
 }
 
 .ids table.ids-table tbody tr:last-child th {
+  border-bottom: 0;
   border-radius: 0 0 0 10px;
 }
 

--- a/apps/minaintyg/src/pages/Certificate/CertificatePage.tsx
+++ b/apps/minaintyg/src/pages/Certificate/CertificatePage.tsx
@@ -41,6 +41,10 @@ export function CertificatePage() {
         <CertificateActions recipient={certificate.metadata.recipient} />
       </div>
 
+      <div className="md:hidden">
+        <PageDivider />
+      </div>
+
       <div className="rounded-[10px] border-stone-line md:border md:p-7 md:shadow-[0_0_2px_0px_rgba(0,0,0,0.3)]">
         <div className="mb-5 flex flex-col justify-between gap-2.5 md:flex-row md:gap-5">
           <h2 className="ids-heading-2">{certificate.metadata.type.name}</h2>
@@ -55,7 +59,7 @@ export function CertificatePage() {
         </div>
         <h3 className="ids-heading-4 mb-0">Händelser</h3>
         <CertificateEventsInfo events={certificate.metadata.events} />
-        <PageDivider />
+
         <article className="ids-certificate">
           <CertificateBody content={certificate.content} />
           <CertificateFooter {...certificate.metadata} />

--- a/apps/minaintyg/src/pages/Certificate/__snapshots__/CertificateListPage.test.tsx.snap
+++ b/apps/minaintyg/src/pages/Certificate/__snapshots__/CertificateListPage.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Should have correct heading 1`] = `
 <h1
-  class="ids-heading-1 text-[min(2.25rem,9.25vw)]/[min(2.25rem,9.25vw)] md:text-5xl"
+  class="ids-heading-1"
 >
   Intyg
 </h1>

--- a/apps/minaintyg/src/pages/Certificate/__snapshots__/CertificatePage.test.tsx.snap
+++ b/apps/minaintyg/src/pages/Certificate/__snapshots__/CertificatePage.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Should have article content 1`] = `
   </ids-expandable>
   <footer>
     <hr
-      class="my-7 border-stone-clear"
+      class="my-7 border-stone-line"
     />
     <h2
       class="ids-heading-3"
@@ -39,7 +39,7 @@ exports[`Should have article content 1`] = `
       </div>
     </address>
     <hr
-      class="my-7 border-stone-clear"
+      class="my-7 border-stone-line"
     />
     <strong>
       Intygs-ID:

--- a/apps/minaintyg/src/pages/Certificate/__snapshots__/SendCertificatePage.test.tsx.snap
+++ b/apps/minaintyg/src/pages/Certificate/__snapshots__/SendCertificatePage.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Should render as expected 1`] = `
     class="ids-content mb-7"
   >
     <h1
-      class="ids-heading-1 text-[min(2.25rem,9.25vw)]/[min(2.25rem,9.25vw)] md:text-5xl"
+      class="ids-heading-1"
     >
       Skicka intyg 
     </h1>
@@ -34,27 +34,27 @@ exports[`Should render as expected 1`] = `
         class="flex flex-col gap-5 md:flex-row md:gap-10"
       >
         <div>
-          <strong
-            class="block"
+          <h3
+            class="ids-heading-4 mb-0"
           >
             Gäller intygsperiod
-          </strong>
+          </h3>
           2021-04-22 - 2021-07-19
         </div>
         <div>
-          <strong
-            class="block"
+          <h3
+            class="ids-heading-4 mb-0"
           >
             Intyg utfärdat
-          </strong>
+          </h3>
           2023-10-10
         </div>
         <div>
-          <strong
-            class="block"
+          <h3
+            class="ids-heading-4 mb-0"
           >
             Skrivet av
-          </strong>
+          </h3>
           Jenny Ström
           , 
           Tommy Claesson

--- a/apps/minaintyg/src/pages/Certificate/components/CertificateCard/CertificateCardSummary.tsx
+++ b/apps/minaintyg/src/pages/Certificate/components/CertificateCard/CertificateCardSummary.tsx
@@ -5,14 +5,14 @@ export function CertificateCardSummary({ summary, timestamp }: { summary: Certif
   const { date } = useFormat()
 
   return (
-    <div className="mb-2.5 flex flex-col place-content-end gap-2.5 border-stone-clear md:mb-5 md:flex-row md:border-b md:pb-5">
+    <div className="mb-2.5 flex flex-col place-content-end gap-2.5 border-stone-line md:mb-5 md:flex-row md:border-b md:pb-5">
       {summary && (
-        <p className="grow">
-          <span className="font-bold">{summary.label}:</span> {summary.value}
-        </p>
+        <div className="grow leading-5">
+          <h4 className="ids-heading-4 mb-0 leading-5 md:inline-block md:after:content-[':']">{summary.label}</h4> {summary.value}
+        </div>
       )}
-      <div className="flex flex-col md:flex-row md:gap-1.5">
-        <span className="font-bold">Intyg utfärdat:</span>
+      <div className="flex flex-col leading-5 md:flex-row md:gap-1.5">
+        <h4 className="ids-heading-4 mb-0 leading-5 md:inline-block md:after:content-[':']">Intyg utfärdat</h4>
         <span>{date(timestamp)}</span>
       </div>
     </div>

--- a/apps/minaintyg/src/pages/Certificate/components/CertificateCard/__snapshots__/CertificateCardSummary.test.tsx.snap
+++ b/apps/minaintyg/src/pages/Certificate/components/CertificateCard/__snapshots__/CertificateCardSummary.test.tsx.snap
@@ -3,28 +3,27 @@
 exports[`Should render correctly with summary 1`] = `
 <div>
   <div
-    class="mb-2.5 flex flex-col place-content-end gap-2.5 border-stone-clear md:mb-5 md:flex-row md:border-b md:pb-5"
+    class="mb-2.5 flex flex-col place-content-end gap-2.5 border-stone-line md:mb-5 md:flex-row md:border-b md:pb-5"
   >
-    <p
-      class="grow"
+    <div
+      class="grow leading-5"
     >
-      <span
-        class="font-bold"
+      <h4
+        class="ids-heading-4 mb-0 leading-5 md:inline-block md:after:content-[':']"
       >
         Gäller intygsperiod
-        :
-      </span>
+      </h4>
        
       2023-05-09 - 2023-06-23
-    </p>
+    </div>
     <div
-      class="flex flex-col md:flex-row md:gap-1.5"
+      class="flex flex-col leading-5 md:flex-row md:gap-1.5"
     >
-      <span
-        class="font-bold"
+      <h4
+        class="ids-heading-4 mb-0 leading-5 md:inline-block md:after:content-[':']"
       >
-        Intyg utfärdat:
-      </span>
+        Intyg utfärdat
+      </h4>
       <span>
         2023-05-09
       </span>
@@ -36,16 +35,16 @@ exports[`Should render correctly with summary 1`] = `
 exports[`Should render correctly without summary 1`] = `
 <div>
   <div
-    class="mb-2.5 flex flex-col place-content-end gap-2.5 border-stone-clear md:mb-5 md:flex-row md:border-b md:pb-5"
+    class="mb-2.5 flex flex-col place-content-end gap-2.5 border-stone-line md:mb-5 md:flex-row md:border-b md:pb-5"
   >
     <div
-      class="flex flex-col md:flex-row md:gap-1.5"
+      class="flex flex-col leading-5 md:flex-row md:gap-1.5"
     >
-      <span
-        class="font-bold"
+      <h4
+        class="ids-heading-4 mb-0 leading-5 md:inline-block md:after:content-[':']"
       >
-        Intyg utfärdat:
-      </span>
+        Intyg utfärdat
+      </h4>
       <span>
         2023-05-09
       </span>

--- a/apps/minaintyg/src/pages/Certificate/components/CertificateInformation.tsx
+++ b/apps/minaintyg/src/pages/Certificate/components/CertificateInformation.tsx
@@ -7,16 +7,16 @@ export function CertificateInformation({ issued, issuer, summary, unit }: Certif
     <div className="flex flex-col gap-5 md:flex-row md:gap-10">
       {summary && (
         <div>
-          <strong className="block">{summary.label}</strong>
+          <h3 className="ids-heading-4 mb-0">{summary.label}</h3>
           {summary.value}
         </div>
       )}
       <div>
-        <strong className="block">Intyg utfärdat</strong>
+        <h3 className="ids-heading-4 mb-0">Intyg utfärdat</h3>
         {date(issued)}
       </div>
       <div>
-        <strong className="block">Skrivet av</strong>
+        <h3 className="ids-heading-4 mb-0">Skrivet av</h3>
         {issuer.name}, {unit.name}
       </div>
     </div>

--- a/apps/minaintyg/src/pages/Certificate/components/CertificateListFilter/CertificateListFilter.tsx
+++ b/apps/minaintyg/src/pages/Certificate/components/CertificateListFilter/CertificateListFilter.tsx
@@ -20,25 +20,25 @@ export function CertificateListFilter({ listed }: { listed: number }) {
 
   return (
     <FilterAccordion listed={listed} total={filterOptions.total} noun="intyg">
-      <div className="grid grid-cols-1 gap-5 md:grid-cols-4 md:gap-10">
+      <div className="mb-5 grid grid-cols-1 gap-5 md:grid-cols-2 md:gap-x-10">
         <CertificateStatusFilter options={filterOptions.statuses} />
         <CertificateUnitFilter options={filterOptions.units} />
         <CertificateTypeFilter options={filterOptions.certificateTypes} />
         <CertificateYearFilter options={filterOptions.years} />
-        <div className="flex flex-col gap-5 md:col-span-4 md:flex-row">
-          <IDSButton secondary sblock onClick={() => dispatch(reset())} aria-label="Rensa filter">
-            Rensa filter
-          </IDSButton>
-          <IDSButton
-            sblock
-            onClick={() => {
-              dispatch(submit(omit(filter, ['submitFilters'])))
-            }}
-            aria-label="Filtrera"
-          >
-            Filtrera
-          </IDSButton>
-        </div>
+      </div>
+      <div className="flex flex-col justify-end gap-5 md:flex-row">
+        <IDSButton secondary mblock onClick={() => dispatch(reset())} aria-label="Rensa filter">
+          Rensa filter
+        </IDSButton>
+        <IDSButton
+          mblock
+          onClick={() => {
+            dispatch(submit(omit(filter, ['submitFilters'])))
+          }}
+          aria-label="Filtrera"
+        >
+          Filtrera
+        </IDSButton>
       </div>
     </FilterAccordion>
   )

--- a/apps/minaintyg/src/pages/Certificate/components/CertificateListOrder/CertificateListOrderButton.tsx
+++ b/apps/minaintyg/src/pages/Certificate/components/CertificateListOrder/CertificateListOrderButton.tsx
@@ -5,7 +5,7 @@ export function CertificateListOrderButton({ active, label, onClick }: { active:
   return (
     <button
       type="button"
-      className={classNames(active ? 'font-semibold pointer-events-none' : 'text-sky-base underline')}
+      className={classNames(active ? 'font-semibold pointer-events-none' : 'text-sky-base underline hover:text-sky-dark')}
       onClick={onClick}
       aria-label={label}
     >

--- a/apps/minaintyg/src/pages/Certificate/components/CertificateListOrder/__snapshots__/CertificateListOrder.test.tsx.snap
+++ b/apps/minaintyg/src/pages/Certificate/components/CertificateListOrder/__snapshots__/CertificateListOrder.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Should render with order set to "ascending" 1`] = `
     >
       <button
         aria-label="Nyast först"
-        class="text-sky-base underline"
+        class="text-sky-base underline hover:text-sky-dark"
         type="button"
       >
         Nyast först
@@ -58,7 +58,7 @@ exports[`Should render with order set to "descending" 1`] = `
       </div>
       <button
         aria-label="Äldst först"
-        class="text-sky-base underline"
+        class="text-sky-base underline hover:text-sky-dark"
         type="button"
       >
         Äldst först

--- a/apps/minaintyg/src/pages/Certificate/components/EmptyCertificateListInfo.test.tsx
+++ b/apps/minaintyg/src/pages/Certificate/components/EmptyCertificateListInfo.test.tsx
@@ -1,12 +1,12 @@
-import { render, screen } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { EmptyCertificateListInfo } from './EmptyCertificateListInfo'
 
 it('Should display information if total above 0', () => {
-  render(<EmptyCertificateListInfo total={1} />)
-  expect(screen.getByText(/de filter du valt matchar inga av dina intyg/i)).toBeInTheDocument()
+  const { container } = render(<EmptyCertificateListInfo total={1} />)
+  expect(container).toMatchSnapshot()
 })
 
 it('Should display information if total is 0', () => {
-  render(<EmptyCertificateListInfo total={0} />)
-  expect(screen.getByText(/om du saknar ett intyg, vänd dig till din mottagning/i)).toBeInTheDocument()
+  const { container } = render(<EmptyCertificateListInfo total={0} />)
+  expect(container).toMatchSnapshot()
 })

--- a/apps/minaintyg/src/pages/Certificate/components/EmptyCertificateListInfo.tsx
+++ b/apps/minaintyg/src/pages/Certificate/components/EmptyCertificateListInfo.tsx
@@ -3,8 +3,8 @@ import { IDSAlert } from '@frontend/ids-react-ts'
 export function EmptyCertificateListInfo({ total }: { total: number }) {
   if (total > 0) {
     return (
-      <IDSAlert headline="Inget resultat">
-        <p>De filter du valt matchar inga av dina intyg. </p>
+      <IDSAlert headline="Din filtrering gav inga träffar">
+        <p>Testa att ändra de filter du valt. Du kan också klicka på rensa filter för att se alla dina intyg.</p>
       </IDSAlert>
     )
   }

--- a/apps/minaintyg/src/pages/Certificate/components/SendCertificateActions/SendCertificateActions.tsx
+++ b/apps/minaintyg/src/pages/Certificate/components/SendCertificateActions/SendCertificateActions.tsx
@@ -14,7 +14,7 @@ export function SendCertificateActions({ id, recipient }: { id: string; recipien
       {isError && <SendCertificateErrorAlert recipient={recipient} />}
       {isSuccess && recipient.sent && <SendCertificateSuccessAlert recipient={recipient} />}
       <div className="flex flex-col gap-5 py-5 sm:flex-row">
-        <IDSButton role="button" sblock secondary onClick={() => navigate('..')}>
+        <IDSButton role="button" sblock secondary={!isSuccess} onClick={() => navigate('..')}>
           Tillbaka till intyget
         </IDSButton>
 

--- a/apps/minaintyg/src/pages/Certificate/components/__snapshots__/CertificateInformation.test.tsx.snap
+++ b/apps/minaintyg/src/pages/Certificate/components/__snapshots__/CertificateInformation.test.tsx.snap
@@ -6,27 +6,27 @@ exports[`Should render as expected 1`] = `
     class="flex flex-col gap-5 md:flex-row md:gap-10"
   >
     <div>
-      <strong
-        class="block"
+      <h3
+        class="ids-heading-4 mb-0"
       >
         Avser diagnos
-      </strong>
+      </h3>
       Downs syndrom
     </div>
     <div>
-      <strong
-        class="block"
+      <h3
+        class="ids-heading-4 mb-0"
       >
         Intyg utfärdat
-      </strong>
+      </h3>
       2022-11-10
     </div>
     <div>
-      <strong
-        class="block"
+      <h3
+        class="ids-heading-4 mb-0"
       >
         Skrivet av
-      </strong>
+      </h3>
       Mats Andersson
       , 
       Jansson, Lundqvist Kommanditbolag

--- a/apps/minaintyg/src/pages/Certificate/components/__snapshots__/EmptyCertificateListInfo.test.tsx.snap
+++ b/apps/minaintyg/src/pages/Certificate/components/__snapshots__/EmptyCertificateListInfo.test.tsx.snap
@@ -1,0 +1,28 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Should display information if total above 0 1`] = `
+<div>
+  <ids-alert
+    role="alert"
+  >
+    <p>
+      Testa att ändra de filter du valt. Du kan också klicka på rensa filter för att se alla dina intyg.
+    </p>
+  </ids-alert>
+</div>
+`;
+
+exports[`Should display information if total is 0 1`] = `
+<div>
+  <ids-alert
+    role="alert"
+  >
+    <p>
+      I Intyg visas endast intyg som utfärdats digitalt till dig. Intyg har ingen ombudsfunktion och du kan inte ladda upp egna intyg.
+    </p>
+    <p>
+      Om du saknar ett intyg, vänd dig till din mottagning.
+    </p>
+  </ids-alert>
+</div>
+`;


### PR DESCRIPTION
## General

- Breadcrumbs should have IDS link styling
- `ScrollTopButton` should appear earlier.
- `PageDivider` should use a brighter color
- Convert `<strong>` to heading elements

## List view

- Update alert text when filter yield no result
- Filter options in 2x2 grid
- Filter text should contain "Visar"
- Move action buttons to the right

## Read view

- Add `PageDivider` between actions and certificate on desktop
- Remove `PageDivider` between certificate information and content
- Add rounded corner for last header cell in `<tbody>`

## Send view

- "Tillbaka till intyget" should be made primary when certificate is successfully sent