### PR TITLE
Add fallbacks to fonts

### DIFF
--- a/apps/minaintyg/src/index.css
+++ b/apps/minaintyg/src/index.css
@@ -5,6 +5,11 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --font-family_1: 'Open Sans', Roboto, 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', Arial, sans-serif;
+  --font-family_2: Inter, Roboto, 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', Arial, sans-serif;
+}
+
 summary::-webkit-details-marker {
   display: none;
 }

--- a/apps/rehabstod/src/index.css
+++ b/apps/rehabstod/src/index.css
@@ -5,6 +5,11 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --font-family_1: 'Open Sans', Roboto, 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', Arial, sans-serif;
+  --font-family_2: Poppins, Roboto, 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', Arial, sans-serif;
+}
+
 @page {
   size: A4 landscape;
 }


### PR DESCRIPTION
IDS has no fallbacks on the font families, in case of failed download or missing glyphs the applications can look broken.

For 1177, fonts are currently defined as:
```css
--font-family_1: "Open Sans";
--font-family_2: "Inter";
```

Fallbacks are from https://github.com/system-fonts/modern-font-stacks