### PR TITLE
INTYGFV-16405 & INTYGFV-16424: Only fetch ICF when needed

### DIFF
--- a/apps/webcert/package.json
+++ b/apps/webcert/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@frontend/filtrex": "workspace:*",
+    "@frontend/utils": "workspace:^",
     "@reduxjs/toolkit": "1.7.2",
     "axios": "^1.6.0",
     "classnames": "^2.3.2",

--- a/apps/webcert/src/components/fmb/FMBPanel.tsx
+++ b/apps/webcert/src/components/fmb/FMBPanel.tsx
@@ -1,9 +1,11 @@
 import { isEqual } from 'lodash-es'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 import PanelHeader from '../../feature/certificate/CertificateSidePanel/PanelHeader'
+import { initializeFMBPanel } from '../../store/fmb/fmbActions'
 import { getDiagnosisListValue, getFMBDiagnosisCodes } from '../../store/fmb/fmbSelectors'
+import { useAppDispatch } from '../../store/store'
 import { FMBDiagnosisCodeInfo } from '../../types'
 import ImageCentered from '../image/image/ImageCentered'
 import FMBPanelDiagnoses from './FMBPanelDiagnoses'
@@ -16,6 +18,7 @@ export const Italic = styled.p`
 `
 
 const FMBPanel: React.FC = () => {
+  const dispatch = useAppDispatch()
   const fmbDiagnosisCodes = useSelector(getFMBDiagnosisCodes, isEqual)
   const [selectedDiagnosisCode, setSelectedDiagnosisCode] = useState<FMBDiagnosisCodeInfo>()
   const diagnosisValue = useSelector(getDiagnosisListValue, isEqual)
@@ -54,6 +57,10 @@ const FMBPanel: React.FC = () => {
   if (!isEmpty() && isNoDiagnosesSelected()) {
     selectDefaultDiagnosis()
   }
+
+  useEffect(() => {
+    dispatch(initializeFMBPanel())
+  })
 
   return !isIcd10Chosen ? (
     <ImageCentered imgSrc={noDiagnosisIcon} alt={'Inget FMB-stöd'}>

--- a/apps/webcert/src/feature/certificate/Certificate.tsx
+++ b/apps/webcert/src/feature/certificate/Certificate.tsx
@@ -113,11 +113,11 @@ const Certificate: React.FC = () => {
                 const category = structure[0].component === ConfigTypes.CATEGORY ? structure[0] : null
                 return (
                   <CategoryWrapper key={index}>
-                    {structure.map(({ id, subQuestionIds, component }, index) => {
+                    {structure.map(({ id, subQuestionIds, component }) => {
                       if (component === ConfigTypes.CATEGORY) {
-                        return <Category key={index} id={id} />
+                        return <Category key={id} id={id} />
                       } else {
-                        return <QuestionWithSubQuestions key={index} questionIds={[id, ...subQuestionIds]} />
+                        return <QuestionWithSubQuestions key={id} questionIds={[id, ...subQuestionIds]} />
                       }
                     })}
                     {category && <QuestionValidationError id={category.id} />}

--- a/apps/webcert/src/feature/certificate/CertificateSidePanel/CertificateSidePanel.tsx
+++ b/apps/webcert/src/feature/certificate/CertificateSidePanel/CertificateSidePanel.tsx
@@ -1,36 +1,31 @@
-import { isEqual } from 'lodash-es'
+import { isTruthy } from '@frontend/utils'
 import React, { ReactNode, useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 import { Tabs } from '../../../components/Tabs/Tabs'
 import FMBPanel from '../../../components/fmb/FMBPanel'
 import QuestionNotAvailablePanel from '../../../components/question/QuestionNotAvailablePanel'
 import QuestionPanel from '../../../components/question/QuestionPanel'
 import SrsPanel from '../../../components/srs/panel/SrsPanel'
 import { LightbulpIcon } from '../../../images'
-import { getCertificate, getIsShowSpinner, getResourceLinks } from '../../../store/certificate/certificateSelectors'
+import { getCertificate, getIsShowSpinner, getResourceLink } from '../../../store/certificate/certificateSelectors'
 import { getIsLoadingQuestions, getQuestions } from '../../../store/question/questionSelectors'
 import { logSrsInteraction } from '../../../store/srs/srsActions'
-import { ResourceLink, ResourceLinkType, SrsEvent } from '../../../types'
+import { useAppSelector } from '../../../store/store'
+import { ResourceLinkType, SrsEvent } from '../../../types'
 import AboutCertificatePanel from './AboutCertificatePanel'
 
 const CertificateSidePanel: React.FC = () => {
-  const showSpinner = useSelector(getIsShowSpinner)
-  const resourceLinks = useSelector(getResourceLinks, isEqual)
-  const questions = useSelector(getQuestions, isEqual)
-  const isLoadingQuestions = useSelector(getIsLoadingQuestions)
-  const certificate = useSelector(getCertificate, isEqual)
-  const resourceLinksForTabs = [
-    ResourceLinkType.SRS_FULL_VIEW,
-    ResourceLinkType.SRS_MINIMIZED_VIEW,
-    ResourceLinkType.FMB,
-    ResourceLinkType.QUESTIONS,
-    ResourceLinkType.QUESTIONS_NOT_AVAILABLE,
-  ]
-
-  const availableTabs = resourceLinksForTabs.reduce<ResourceLink[]>((result, type) => {
-    const link = resourceLinks.find((link) => type === link.type)
-    return link ? [...result, link] : result
-  }, [])
+  const showSpinner = useAppSelector(getIsShowSpinner)
+  const isLoadingQuestions = useAppSelector(getIsLoadingQuestions)
+  const hasUnhandledQuestions = useAppSelector((state) => getQuestions(state).filter((question) => !question.handled).length > 0)
+  const hasCertificate = useAppSelector((state) => Boolean(getCertificate(state)))
+  const availableTabs = [
+    useAppSelector(getResourceLink(ResourceLinkType.SRS_FULL_VIEW)),
+    useAppSelector(getResourceLink(ResourceLinkType.SRS_MINIMIZED_VIEW)),
+    useAppSelector(getResourceLink(ResourceLinkType.FMB)),
+    useAppSelector(getResourceLink(ResourceLinkType.QUESTIONS)),
+    useAppSelector(getResourceLink(ResourceLinkType.QUESTIONS_NOT_AVAILABLE)),
+  ].filter(isTruthy)
 
   const [selectedTabIndex, setSelectedTabIndex] = useState(0)
   const [hasUpdatedTab, setHasUpdatedTab] = useState(false)
@@ -39,16 +34,15 @@ const CertificateSidePanel: React.FC = () => {
   const dispatch = useDispatch()
 
   useEffect(() => {
-    if (certificate && !showSpinner && !isLoadingQuestions) {
+    if (hasCertificate && !showSpinner && !isLoadingQuestions) {
       const questionsTab = availableTabs.findIndex((tab) => tab.type === ResourceLinkType.QUESTIONS)
-      const unhandledQuestions = questions.filter((question) => !question.handled)
-      if (questionsTab !== -1 && unhandledQuestions.length > 0 && !hasUpdatedTab) {
+      if (questionsTab !== -1 && hasUnhandledQuestions && !hasUpdatedTab) {
         setSelectedTabIndex(questionsTab)
         setHasUpdatedTab(true)
       }
       setHasLoaded(true)
     }
-  }, [certificate, showSpinner, questions, hasUpdatedTab, isLoadingQuestions, availableTabs])
+  }, [hasCertificate, showSpinner, hasUpdatedTab, isLoadingQuestions, availableTabs, hasUnhandledQuestions])
 
   useEffect(() => {
     if (hasLoaded) {

--- a/apps/webcert/src/feature/certificate/Modals/DeathCertificateConfirmModalIntegrated.test.tsx
+++ b/apps/webcert/src/feature/certificate/Modals/DeathCertificateConfirmModalIntegrated.test.tsx
@@ -7,6 +7,9 @@ import { Provider } from 'react-redux'
 import { Router } from 'react-router-dom'
 import { vi } from 'vitest'
 import { createPatient } from '../../../components/patient/patientTestUtils'
+import { fakeCertificate } from '../../../faker'
+import { updateCertificate } from '../../../store/certificate/certificateActions'
+import { certificateMiddleware } from '../../../store/certificate/certificateMiddleware'
 import { configureApplicationStore } from '../../../store/configureApplicationStore'
 import { errorMiddleware } from '../../../store/error/errorMiddleware'
 import dispatchHelperMiddleware, { clearDispatchedActions } from '../../../store/test/dispatchHelperMiddleware'
@@ -22,12 +25,7 @@ const renderComponent = (isOpen: boolean) => {
   render(
     <Provider store={testStore}>
       <Router history={history}>
-        <DeathCertificateConfirmModalIntegrated
-          patient={createPatient(PERSON_ID)}
-          certificateId="certificateId"
-          setOpen={setOpen}
-          open={isOpen}
-        />
+        <DeathCertificateConfirmModalIntegrated certificateId="certificateId" setOpen={setOpen} open={isOpen} />
       </Router>
     </Provider>
   )
@@ -35,7 +33,8 @@ const renderComponent = (isOpen: boolean) => {
 
 describe('DeathCertificateConfirmModalIntegrated', () => {
   beforeEach(() => {
-    testStore = configureApplicationStore([dispatchHelperMiddleware, errorMiddleware])
+    testStore = configureApplicationStore([dispatchHelperMiddleware, errorMiddleware, certificateMiddleware])
+    testStore.dispatch(updateCertificate(fakeCertificate({ metadata: { patient: createPatient(PERSON_ID) } })))
   })
 
   afterEach(() => {
@@ -90,11 +89,11 @@ describe('DeathCertificateConfirmModalIntegrated', () => {
       expect(screen.getByText('Gå vidare')).toBeInTheDocument()
     })
 
-    it('should disable confirm button when checkbox in not checked', () => {
+    it('should disable confirm button when checkbox in not checked', async () => {
       renderComponent(true)
       const confirmButton = screen.getByText('Gå vidare')
 
-      expect(confirmButton).toBeDisabled()
+      await expect(confirmButton).toBeDisabled()
     })
 
     it('should enable confirm button when checkbox in checked', async () => {
@@ -103,7 +102,7 @@ describe('DeathCertificateConfirmModalIntegrated', () => {
       await userEvent.click(confirmCheckbox)
 
       const confirmButton = screen.getByText('Gå vidare')
-      expect(confirmButton).toBeEnabled()
+      await expect(confirmButton).toBeEnabled()
     })
   })
 })

--- a/apps/webcert/src/feature/certificate/Modals/DeathCertificateConfirmModalIntegrated.tsx
+++ b/apps/webcert/src/feature/certificate/Modals/DeathCertificateConfirmModalIntegrated.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react'
+import { useSelector } from 'react-redux'
 import styled from 'styled-components'
-import { useDeleteCertificate } from '../hooks/useDeleteCertificate'
 import Checkbox from '../../../components/Inputs/Checkbox'
 import InfoBox from '../../../components/utils/InfoBox'
 import { ConfirmModal } from '../../../components/utils/Modal/ConfirmModal'
-import { Patient } from '../../../types'
+import { RootState } from '../../../store/store'
+import { useDeleteCertificate } from '../hooks/useDeleteCertificate'
 
 interface Props {
-  patient: Patient
   certificateId: string
   setOpen: (val: boolean) => void
   open: boolean
@@ -19,9 +19,14 @@ const ContentWrapper = styled.div`
   gap: 1em;
 `
 
-export const DeathCertificateConfirmModalIntegrated: React.FC<Props> = ({ patient, certificateId, setOpen, open }) => {
+export const DeathCertificateConfirmModalIntegrated: React.FC<Props> = ({ certificateId, setOpen, open }) => {
   const [disabled, setDisabled] = useState(true)
   const deleteCertificate = useDeleteCertificate(certificateId)
+  const patient = useSelector((state: RootState) => state.ui.uiCertificate.certificate?.metadata.patient)
+
+  if (!patient) {
+    return null
+  }
 
   return (
     <ConfirmModal

--- a/apps/webcert/src/feature/certificate/Modals/LuaenaConfirmModalIntegrated.test.tsx
+++ b/apps/webcert/src/feature/certificate/Modals/LuaenaConfirmModalIntegrated.test.tsx
@@ -7,6 +7,9 @@ import { Provider } from 'react-redux'
 import { Router } from 'react-router-dom'
 import { vi } from 'vitest'
 import { createPatient } from '../../../components/patient/patientTestUtils'
+import { fakeCertificate } from '../../../faker'
+import { updateCertificate } from '../../../store/certificate/certificateActions'
+import { certificateMiddleware } from '../../../store/certificate/certificateMiddleware'
 import { configureApplicationStore } from '../../../store/configureApplicationStore'
 import { errorMiddleware } from '../../../store/error/errorMiddleware'
 import dispatchHelperMiddleware, { clearDispatchedActions } from '../../../store/test/dispatchHelperMiddleware'
@@ -22,7 +25,7 @@ const renderComponent = (isOpen: boolean) => {
   render(
     <Provider store={testStore}>
       <Router history={history}>
-        <LuaenaConfirmModalIntegrated patient={createPatient(PERSON_ID)} certificateId="certificateId" setOpen={setOpen} open={isOpen} />
+        <LuaenaConfirmModalIntegrated certificateId="certificateId" setOpen={setOpen} open={isOpen} />
       </Router>
     </Provider>
   )
@@ -30,7 +33,8 @@ const renderComponent = (isOpen: boolean) => {
 
 describe('LuaenaConfirmModalIntegrated', () => {
   beforeEach(() => {
-    testStore = configureApplicationStore([dispatchHelperMiddleware, errorMiddleware])
+    testStore = configureApplicationStore([dispatchHelperMiddleware, errorMiddleware, certificateMiddleware])
+    testStore.dispatch(updateCertificate(fakeCertificate({ metadata: { patient: createPatient(PERSON_ID) } })))
   })
 
   afterEach(() => {
@@ -85,11 +89,11 @@ describe('LuaenaConfirmModalIntegrated', () => {
       expect(screen.getByText('Gå vidare')).toBeInTheDocument()
     })
 
-    it('should disable confirm button when checkbox in not checked', () => {
+    it('should disable confirm button when checkbox in not checked', async () => {
       renderComponent(true)
       const confirmButton = screen.getByText('Gå vidare')
 
-      expect(confirmButton).toBeDisabled()
+      await expect(confirmButton).toBeDisabled()
     })
 
     it('should enable confirm button when checkbox in checked', async () => {
@@ -98,7 +102,7 @@ describe('LuaenaConfirmModalIntegrated', () => {
       await userEvent.click(confirmCheckbox)
 
       const confirmButton = screen.getByText('Gå vidare')
-      expect(confirmButton).toBeEnabled()
+      await expect(confirmButton).toBeEnabled()
     })
   })
 })

--- a/apps/webcert/src/feature/certificate/Modals/LuaenaConfirmModalIntegrated.tsx
+++ b/apps/webcert/src/feature/certificate/Modals/LuaenaConfirmModalIntegrated.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react'
+import { useSelector } from 'react-redux'
 import styled from 'styled-components'
-import { useDeleteCertificate } from '../hooks/useDeleteCertificate'
 import Checkbox from '../../../components/Inputs/Checkbox'
 import InfoBox from '../../../components/utils/InfoBox'
 import { ConfirmModal } from '../../../components/utils/Modal/ConfirmModal'
-import { Patient } from '../../../types'
+import { RootState } from '../../../store/store'
+import { useDeleteCertificate } from '../hooks/useDeleteCertificate'
 
 interface Props {
-  patient: Patient
   certificateId: string
   setOpen: (val: boolean) => void
   open: boolean
@@ -19,9 +19,14 @@ const ContentWrapper = styled.div`
   gap: 1em;
 `
 
-export const LuaenaConfirmModalIntegrated: React.FC<Props> = ({ patient, certificateId, setOpen, open }) => {
+export const LuaenaConfirmModalIntegrated: React.FC<Props> = ({ certificateId, setOpen, open }) => {
   const [disabled, setDisabled] = useState(true)
   const deleteCertificate = useDeleteCertificate(certificateId)
+  const patient = useSelector((state: RootState) => state.ui.uiCertificate.certificate?.metadata.patient)
+
+  if (!patient) {
+    return null
+  }
 
   return (
     <ConfirmModal

--- a/apps/webcert/src/feature/certificate/Question/QuestionComplements.tsx
+++ b/apps/webcert/src/feature/certificate/Question/QuestionComplements.tsx
@@ -1,0 +1,34 @@
+import { isEqual } from 'lodash-es'
+import styled from 'styled-components'
+import { getComplementsForQuestions } from '../../../store/certificate/certificateSelectors'
+import { useAppSelector } from '../../../store/store'
+
+const Complement = styled.div`
+  display: flex;
+  align-items: top;
+  justify-content: space-between;
+  padding: 5px;
+`
+
+const ComplementMessage = styled.div`
+  white-space: pre-line;
+`
+
+export function QuestionComplements({ questionIds }: { questionIds: string[] }) {
+  const complements = useAppSelector(getComplementsForQuestions(questionIds), isEqual)
+  return (
+    <>
+      {complements.map((complement, index) => (
+        <div key={index} className="ic-alert ic-alert--status ic-alert--info iu-p-none iu-my-400">
+          <Complement>
+            <i className="ic-alert__icon ic-info-icon iu-m-none" />
+            <div className="iu-fullwidth iu-pl-300 iu-fs-200">
+              <p className="iu-fw-heading">Kompletteringsbegäran:</p>
+              <ComplementMessage>{complement.message}</ComplementMessage>
+            </div>
+          </Complement>
+        </div>
+      ))}
+    </>
+  )
+}

--- a/apps/webcert/src/feature/certificate/Question/QuestionHeading.tsx
+++ b/apps/webcert/src/feature/certificate/Question/QuestionHeading.tsx
@@ -1,7 +1,7 @@
-import { useSelector } from 'react-redux'
 import styled, { css } from 'styled-components'
 import { getQuestion } from '../../../store/certificate/certificateSelectors'
-import { ConfigTypes } from '../../../types'
+import { useAppSelector } from '../../../store/store'
+import { CertificateDataElement, ConfigTypes } from '../../../types'
 
 const HeadlineStyles = css`
   margin-bottom: 0.625rem;
@@ -18,45 +18,34 @@ const QuestionSubHeadline = styled.h5`
   ${HeadlineStyles}
 `
 
-interface QuestionHeadingProps {
-  header?: string
-  questionId: string
-  hideLabel: boolean
-  label?: string
-  readOnly: boolean
-  text: string
-  questionParent: string
-}
+export function QuestionHeading({ question: { id, parent, config, readOnly } }: { question: CertificateDataElement }) {
+  const questionParent = useAppSelector(getQuestion(parent))
+  const questionTypeIsCategory = questionParent && questionParent.config.type === ConfigTypes.CATEGORY
+  const hideLabel = config.type === ConfigTypes.UE_CAUSE_OF_DEATH
 
-const QuestionHeading: React.FC<QuestionHeadingProps> = ({ readOnly, header, questionId, hideLabel, text, label, questionParent }) => {
-  const parent = useSelector(getQuestion(questionParent))
-  const questionTypeIsCategory = parent && parent.config.type === ConfigTypes.CATEGORY
-
-  return header ? (
+  return config.header ? (
     <>
-      <QuestionHeadline id={questionId} className={`iu-fw-heading iu-fs-300 iu-mb-200`}>
-        {header}
+      <QuestionHeadline id={id} className={`iu-fw-heading iu-fs-300 iu-mb-200`}>
+        {config.header}
       </QuestionHeadline>
-      <QuestionSubHeadline className={`iu-fw-heading iu-fs-200`}>{text}</QuestionSubHeadline>
-      {readOnly && !hideLabel && <QuestionSubHeadline className={`iu-fw-heading iu-fs-200`}>{label}</QuestionSubHeadline>}
+      <QuestionSubHeadline className={`iu-fw-heading iu-fs-200`}>{config.text}</QuestionSubHeadline>
+      {readOnly && !hideLabel && <QuestionSubHeadline className={`iu-fw-heading iu-fs-200`}>{config.label}</QuestionSubHeadline>}
     </>
   ) : questionTypeIsCategory ? (
     <>
-      <QuestionHeadline id={questionId} className={`iu-fw-heading iu-fs-300`}>
-        {text}
+      <QuestionHeadline id={id} className={`iu-fw-heading iu-fs-300`}>
+        {config.text}
       </QuestionHeadline>
       {readOnly && !hideLabel && (
-        <QuestionHeadline id={questionId} className={`iu-fw-heading iu-fs-300`}>
-          {label}
+        <QuestionHeadline id={id} className={`iu-fw-heading iu-fs-300`}>
+          {config.label}
         </QuestionHeadline>
       )}
     </>
   ) : (
     <>
-      <QuestionSubHeadline className={`iu-fw-heading iu-fs-200`}>{text}</QuestionSubHeadline>
-      {readOnly && !hideLabel && <QuestionSubHeadline className={`iu-fw-heading iu-fs-200`}>{label}</QuestionSubHeadline>}
+      <QuestionSubHeadline className={`iu-fw-heading iu-fs-200`}>{config.text}</QuestionSubHeadline>
+      {readOnly && !hideLabel && <QuestionSubHeadline className={`iu-fw-heading iu-fs-200`}>{config.label}</QuestionSubHeadline>}
     </>
   )
 }
-
-export default QuestionHeading

--- a/apps/webcert/src/feature/certificate/Question/QuestionUeResolve.tsx
+++ b/apps/webcert/src/feature/certificate/Question/QuestionUeResolve.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import InfoBox from '../../../components/utils/InfoBox'
+import { CertificateDataElement, ConfigTypes } from '../../../types'
 import UeCauseOfDeath from '../UnifiedEdit/UeCauseOfDeath/UeCauseOfDeath'
 import UeCauseOfDeathList from '../UnifiedEdit/UeCauseOfDeath/UeCauseOfDeathList'
 import UeCheckbox from '../UnifiedEdit/UeCheckbox/UeCheckbox'
@@ -25,8 +27,6 @@ import UeViewTable from '../UnifiedEdit/UeViewTable/UeViewTable'
 import UeViewText from '../UnifiedEdit/UeViewText/UeViewText'
 import UeVisualAcuity from '../UnifiedEdit/UeVisualAcuity/UeVisualAcuity'
 import UeYear from '../UnifiedEdit/UeYear/UeYear'
-import InfoBox from '../../../components/utils/InfoBox'
-import { CertificateDataElement, ConfigTypes } from '../../../types'
 
 interface Props {
   question: CertificateDataElement

--- a/apps/webcert/src/store/certificate/certificateSelectors.ts
+++ b/apps/webcert/src/store/certificate/certificateSelectors.ts
@@ -10,6 +10,7 @@ import {
   CertificateSignStatus,
   CertificateStatus,
   Complement,
+  ConfigTypes,
   ModalData,
   Patient,
   PersonId,
@@ -45,6 +46,15 @@ export const getQuestion =
   (id: string) =>
   (state: RootState): CertificateDataElement | undefined =>
     state.ui.uiCertificate.certificate?.data[id]
+
+export const displayAsMandatory =
+  (questionId: string) =>
+  (state: RootState): boolean => {
+    const question = getQuestion(questionId)(state)
+    return (
+      (!question?.readOnly && question?.mandatory && !question?.disabled && question.config.type !== ConfigTypes.UE_VISUAL_ACUITY) ?? false
+    )
+  }
 
 export const getIsComplementingCertificate = (state: RootState): boolean => {
   const metadata = state.ui.uiCertificate.certificate?.metadata
@@ -189,6 +199,10 @@ export const getVisibleValidationErrors =
 export const getCertificateEvents = (state: RootState): CertificateEvent[] => state.ui.uiCertificate.certificateEvents
 
 export const getResourceLinks = (state: RootState): ResourceLink[] => state.ui.uiCertificate.certificate?.links ?? []
+export const getResourceLink =
+  (type: ResourceLinkType) =>
+  (state: RootState): ResourceLink | undefined =>
+    state.ui.uiCertificate.certificate?.links.find((link) => link.type === type)
 
 export const getIsLocked = (state: RootState): boolean =>
   state.ui.uiCertificate.certificate?.metadata.status === CertificateStatus.LOCKED ||

--- a/apps/webcert/src/store/fmb/fmbActions.ts
+++ b/apps/webcert/src/store/fmb/fmbActions.ts
@@ -1,6 +1,6 @@
 import { createAction } from '@reduxjs/toolkit'
+import { FMBDiagnosisCodeInfo, ValueDateRangeList, ValueDiagnosisList } from '../../types'
 import { FunctionDisabler, TOGGLE_FUNCTION_DISABLER } from '../../utils/functionDisablerUtils'
-import { ValueDateRangeList, FMBDiagnosisCodeInfo, ValueDiagnosisList } from '../../types'
 
 export interface FMBDiagnoseRequest {
   icd10Code: string
@@ -48,3 +48,5 @@ export const validateSickLeavePeriodSuccess = createAction<ValidateSickLeavePeri
 export const validateSickLeavePeriodError = createAction(`${FMB} Validate sick leave period error`)
 
 export const toggleFMBFunctionDisabler = createAction<FunctionDisabler>(`${FMB} ${TOGGLE_FUNCTION_DISABLER}`)
+
+export const initializeFMBPanel = createAction(`${FMB} Initialize FMB Panel`)

--- a/apps/webcert/src/store/fmb/fmbMiddleware.test.ts
+++ b/apps/webcert/src/store/fmb/fmbMiddleware.test.ts
@@ -20,6 +20,7 @@ import { configureApplicationStore } from '../configureApplicationStore'
 import {
   FMBDiagnoseRequest,
   getFMBDiagnosisCodeInfo,
+  initializeFMBPanel,
   setDiagnosisListValue,
   setPatientId,
   setSickLeavePeriodValue,
@@ -232,7 +233,7 @@ describe('Test FMB middleware', () => {
     })
   })
 
-  describe('Handle UpdateCertificateDataElement', () => {
+  describe('Handle 1CertificateDataElement', () => {
     beforeEach(() => {
       testStore.dispatch(updateFMBPanelActive(true))
     })
@@ -404,6 +405,7 @@ describe('Test FMB middleware', () => {
       expect(testStore.getState().ui.uiFMB.fmbDiagnosisCodeInfo.length).toEqual(0)
       expect(fakeAxios.history.get.length).toBe(0)
     })
+
     it('should use previousPersonId if reserveId is true and previousPersonId exists', async () => {
       const fmbDiagnosisRequest = getFMBDiagnoseRequest('F500', 0)
       const expectedPersonId = '201212121212'
@@ -416,9 +418,11 @@ describe('Test FMB middleware', () => {
       certificate.metadata.patient.previousPersonId = patientId
 
       testStore.dispatch(updateCertificate(certificate))
+      testStore.dispatch(initializeFMBPanel())
 
       expect(testStore.getState().ui.uiFMB.patientId).toEqual(expectedPersonId)
     })
+
     it('should use personId if reserveId is true and previousPersonId is missing', async () => {
       const fmbDiagnosisRequest = getFMBDiagnoseRequest('F500', 0)
       const expectedPersonId = '1912121212'
@@ -426,6 +430,7 @@ describe('Test FMB middleware', () => {
       certificate.metadata.patient.reserveId = true
 
       testStore.dispatch(updateCertificate(certificate))
+      testStore.dispatch(initializeFMBPanel())
 
       expect(testStore.getState().ui.uiFMB.patientId).toEqual(expectedPersonId)
     })
@@ -436,6 +441,7 @@ describe('Test FMB middleware', () => {
       certificate.metadata.patient.reserveId = false
 
       testStore.dispatch(updateCertificate(certificate))
+      testStore.dispatch(initializeFMBPanel())
 
       expect(testStore.getState().ui.uiFMB.patientId).toEqual(expectedPersonId)
     })
@@ -455,6 +461,7 @@ describe('Test FMB middleware', () => {
       const fmbDiagnosisRequest = getFMBDiagnoseRequest('A01', 0)
 
       testStore.dispatch(updateCertificate(getCertificate([fmbDiagnosisRequest])))
+      testStore.dispatch(initializeFMBPanel())
 
       await flushPromises()
       expect(fakeAxios.history.get.length).toBe(0)
@@ -467,6 +474,7 @@ describe('Test FMB middleware', () => {
       fakeAxios.onGet(`/api/fmb/${fmbDiagnosisRequest.icd10Code}`).reply(200, fmbDiagnosisResponse)
 
       testStore.dispatch(updateCertificate(getCertificate([fmbDiagnosisRequest], true)))
+      testStore.dispatch(initializeFMBPanel())
 
       await flushPromises()
       expect(testStore.getState().ui.uiFMB.fmbDiagnosisCodeInfo[0]).toEqual(expectedFMBDiagnosisInfo)
@@ -481,6 +489,7 @@ describe('Test FMB middleware', () => {
       fakeAxios.onGet(`/api/fmb/${fmbDiagnosisRequest.icd10Code}`).reply(200, fmbDiagnosisResponse)
 
       testStore.dispatch(updateCertificate(getCertificate([fmbDiagnosisRequest], true)))
+      testStore.dispatch(initializeFMBPanel())
 
       await flushPromises()
       expect(testStore.getState().ui.uiFMB.fmbDiagnosisCodeInfo[0]).toEqual(expectedFMBDiagnosisInfo)

--- a/apps/webcert/src/store/icf/icfMiddleware.test.ts
+++ b/apps/webcert/src/store/icf/icfMiddleware.test.ts
@@ -6,13 +6,13 @@ import {
   getCodeElement,
   getDiagnosisElementWithCodeSystem,
 } from '../../components/icf/icfTestUtils'
+import { Certificate, CertificateStatus, Icd10Code, IcfCode, IcfTitles } from '../../types'
 import { flushPromises } from '../../utils/flushPromises'
 import { apiMiddleware } from '../api/apiMiddleware'
 import { updateCertificate, updateCertificateDataElement } from '../certificate/certificateActions'
 import { configureApplicationStore } from '../configureApplicationStore'
 import { IcfRequest, IcfResponse, getIcfCodes, updateIcfCodes } from './icfActions'
 import { icfMiddleware } from './icfMiddleware'
-import { IcfTitles, Certificate, CertificateStatus, IcfCode, Icd10Code } from '../../types'
 
 const getCertificate = (icfTitles: IcfTitles): Certificate => ({
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/apps/webcert/src/store/icf/icfMiddleware.ts
+++ b/apps/webcert/src/store/icf/icfMiddleware.ts
@@ -1,5 +1,7 @@
 import { AnyAction } from '@reduxjs/toolkit'
+import { isEqual } from 'lodash-es'
 import { Dispatch, Middleware, MiddlewareAPI } from 'redux'
+import { CertificateDataValueType, ValueDiagnosisList, ValueType } from '../../types'
 import { apiCallBegan } from '../api/apiActions'
 import { updateCertificate, updateCertificateDataElement } from '../certificate/certificateActions'
 import { throwError } from '../error/errorActions'
@@ -13,7 +15,7 @@ import {
   toggleIcfFunctionDisabler,
   updateIcfCodes,
 } from './icfActions'
-import { ValueType, CertificateDataValueType, ValueDiagnosisList } from '../../types'
+import { getOriginalIcd10Codes } from './icfSelectors'
 
 export const handleGetIcfCodes: Middleware<Dispatch> =
   ({ dispatch }: MiddlewareAPI) =>
@@ -50,37 +52,37 @@ const handleGetIcfCodesError: Middleware<Dispatch> =
     dispatch(throwError(createSilentErrorRequestFromApiError(action.payload.error)))
   }
 
-function handleUpdateIcfState(value: ValueType, dispatch: Dispatch<AnyAction>) {
+function handleUpdateIcfState(originalIcd10Codes: string[], value: ValueType, dispatch: Dispatch<AnyAction>) {
   const icdCodes = getIcdCodesFromQuestionValue(value)
 
-  if (icdCodes) {
+  if (icdCodes && !isEqual(icdCodes, originalIcd10Codes)) {
     dispatch(getIcfCodes({ icdCodes: icdCodes }))
     dispatch(setOriginalIcd10Codes(icdCodes))
   }
 }
 
 const handleUpdateCertificate: Middleware<Dispatch> =
-  ({ dispatch }) =>
+  ({ dispatch, getState }) =>
   () =>
   (action: AnyAction): void => {
     for (const questionId in action.payload.data) {
       if (Object.prototype.hasOwnProperty.call(action.payload.data, questionId)) {
         const question = action.payload.data[questionId]
-        handleUpdateIcfState(question.value, dispatch)
+        handleUpdateIcfState(getOriginalIcd10Codes(getState()), question.value, dispatch)
       }
     }
   }
 
 const handleUpdateCertificateDataElement: Middleware<Dispatch> =
-  ({ dispatch }: MiddlewareAPI) =>
+  ({ dispatch, getState }: MiddlewareAPI) =>
   () =>
   (action: AnyAction): void => {
-    handleUpdateIcfState(action.payload.value, dispatch)
+    handleUpdateIcfState(getOriginalIcd10Codes(getState()), action.payload.value, dispatch)
   }
 
 function getIcdCodesFromQuestionValue(value: ValueType | null): string[] | undefined {
   if (value && value.type === CertificateDataValueType.DIAGNOSIS_LIST) {
-    return (value as ValueDiagnosisList).list.filter((code) => code.terminology.toLowerCase().includes('icd')).map((code) => code.code)
+    return (value as ValueDiagnosisList).list.filter((code) => code.terminology.toLowerCase().includes('icd')).map(({ code }) => code)
   } else {
     return undefined
   }

--- a/apps/webcert/src/store/icf/icfReducer.ts
+++ b/apps/webcert/src/store/icf/icfReducer.ts
@@ -1,7 +1,7 @@
 import { createReducer } from '@reduxjs/toolkit'
+import { IcfCodeCollection } from '../../types'
 import { FunctionDisabler, toggleFunctionDisabler } from '../../utils/functionDisablerUtils'
 import { setOriginalIcd10Codes, toggleIcfFunctionDisabler, updateIcfCodes } from './icfActions'
-import { IcfCodeCollection } from '../../types'
 
 export interface AvailableIcfCodes {
   commonCodes: IcfCodeCollection

--- a/apps/webcert/src/store/srs/srsMiddleware.tsx
+++ b/apps/webcert/src/store/srs/srsMiddleware.tsx
@@ -64,6 +64,7 @@ import {
   updateUserClientContext,
   updateUserLaunchFromOrigin,
 } from './srsActions'
+import { getCertificateId } from './srsSelectors'
 
 export const handleGetSRSCodes: Middleware<Dispatch> =
   ({ dispatch }: MiddlewareAPI) =>
@@ -318,6 +319,10 @@ const handleUpdateCertificate: Middleware<Dispatch> =
   ({ dispatch, getState }) =>
   () =>
   (action: PayloadAction<Certificate>): void => {
+    if (action.payload.metadata.id === getCertificateId(getState())) {
+      return
+    }
+
     const clientContext = getUserClientContextForCertificate(action.payload.metadata, getState().ui.uiSRS.userLaunchFromOrigin)
     dispatch(resetState())
     dispatch(updateUserClientContext(clientContext))

--- a/apps/webcert/src/store/store.ts
+++ b/apps/webcert/src/store/store.ts
@@ -1,18 +1,18 @@
-import { useDispatch } from 'react-redux'
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
 import { apiMiddleware } from './api/apiMiddleware'
 import { certificateMiddleware } from './certificate/certificateMiddleware'
-import { userMiddleware } from './user/userMiddleware'
+import { configureApplicationStore } from './configureApplicationStore'
+import { errorMiddleware } from './error/errorMiddleware'
 import { fmbMiddleware } from './fmb/fmbMiddleware'
+import { icfMiddleware } from './icf/icfMiddleware'
+import { listMiddleware } from './list/listMiddleware'
+import { patientMiddleware } from './patient/patientMiddleware'
+import { questionMiddleware } from './question/questionMiddleware'
+import { sessionMiddleware } from './session/sessionMiddleware'
+import { srsMiddleware } from './srs/srsMiddleware'
+import { userMiddleware } from './user/userMiddleware'
 import { utilsMiddleware } from './utils/utilsMiddleware'
 import { welcomeMiddleware } from './welcome/welcomeMiddleware'
-import { questionMiddleware } from './question/questionMiddleware'
-import { icfMiddleware } from './icf/icfMiddleware'
-import { sessionMiddleware } from './session/sessionMiddleware'
-import { errorMiddleware } from './error/errorMiddleware'
-import { patientMiddleware } from './patient/patientMiddleware'
-import { listMiddleware } from './list/listMiddleware'
-import { configureApplicationStore } from './configureApplicationStore'
-import { srsMiddleware } from './srs/srsMiddleware'
 
 const store = configureApplicationStore([
   apiMiddleware,
@@ -33,5 +33,6 @@ const store = configureApplicationStore([
 export type RootState = ReturnType<typeof store.getState>
 export type AppDispatch = typeof store.dispatch
 export const useAppDispatch = (): AppDispatch => useDispatch<AppDispatch>()
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
 
 export default store

--- a/apps/webcert/tsconfig.json
+++ b/apps/webcert/tsconfig.json
@@ -10,7 +10,8 @@
     "types": ["vitest/globals", "@types/testing-library__jest-dom"],
     // Tell compiler to use React 17 dependencies.
     "paths": {
-      "react": ["./node_modules/@types/react"]
+      "react": ["./node_modules/@types/react"],
+      "@frontend/utils": ["../../packages/utils/src/index.ts"]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -483,6 +483,9 @@ importers:
       '@frontend/filtrex':
         specifier: workspace:*
         version: link:../../packages/filtrex
+      '@frontend/utils':
+        specifier: workspace:^
+        version: link:../../packages/utils
       '@reduxjs/toolkit':
         specifier: 1.7.2
         version: 1.7.2(react-redux@7.2.9)(react@17.0.2)


### PR DESCRIPTION
__Fixes__

* Component re-rendering caused by imprecise `useSelector`
  - Certificate
  - CertificatePage
  - Question
  - QuestionWithSubQuestion
  - CertificateSidePanel
* Unnecessary state updated due to listening for `updateCertificate` redux action.

-------
To make sure that components are not re-render unnecessary, it helps to use `isEqual` or more precise selectors - for example:
```
const certificateId = useSelector((state) => state.ui.uiCertificate.certificate?.metadata.id)
```

instead of
```
const metadata = useSelector((state) => state.ui.uiCertificate.certificate?.metadata)
const certificateId = metadata.id
```

These updates can be identified using react DevTools extension for chrome.

`updateCertificate` action was previously only called when a certificate was initially loaded. This has changed to be used when validating certificates after updating fields. Middleware for SRS and FMB used for the side panel has been listening for this event and treating it as the initial load event for certificates.