### PR TITLE
INTYGFV-16701: Simplify ping and session handling

### DIFF
--- a/apps/minaintyg/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/apps/minaintyg/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,11 +1,13 @@
+import { skipToken } from '@reduxjs/toolkit/query'
 import { ReactNode } from 'react'
 import { useGetSessionPingQuery } from '../../store/api'
-import { useGetUserQuery } from '../../store/hooks'
+import { useAppSelector, useGetUserQuery } from '../../store/hooks'
 import { SessionDialog } from '../SessionDialog/SessionDialog'
 
 export function ProtectedRoute({ children }: { children: ReactNode }): React.JSX.Element | null {
   const { isError, isLoading, data: user } = useGetUserQuery()
-  const { data: session } = useGetSessionPingQuery(undefined, {
+  const hasSession = useAppSelector((state) => state.sessionSlice.hasSession)
+  const { data: session } = useGetSessionPingQuery(hasSession ? undefined : skipToken, {
     pollingInterval: 30e3,
     skip: !user,
   })

--- a/apps/minaintyg/src/components/error/ErrorBoundary.test.tsx
+++ b/apps/minaintyg/src/components/error/ErrorBoundary.test.tsx
@@ -2,13 +2,13 @@ import { render } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { Route, RouterProvider, createMemoryRouter, createRoutesFromElements } from 'react-router-dom'
 import { waitForRequest } from '../../mocks/server'
-import { startSession } from '../../store/slice/session.slice'
+import { api } from '../../store/api'
 import { store } from '../../store/store'
 import { ErrorBoundary } from './ErrorBoundary'
 
 it('Should log client error for active session', async () => {
   const pendingLogRequest = waitForRequest('POST', '/api/log/error')
-  store.dispatch(startSession())
+  store.dispatch(api.endpoints.getUser.initiate())
   render(
     <Provider store={store}>
       <RouterProvider

--- a/apps/minaintyg/src/pages/Certificate/CertificatePage.test.tsx
+++ b/apps/minaintyg/src/pages/Certificate/CertificatePage.test.tsx
@@ -11,7 +11,7 @@ import {
   certificateRecipientSchema,
   certificateSchema,
 } from '../../schema/certificate.schema'
-import { startSession } from '../../store/slice/session.slice'
+import { api } from '../../store/api'
 import { store } from '../../store/store'
 import { CertificatePage } from './CertificatePage'
 
@@ -142,7 +142,7 @@ describe('Unable to load certificate', () => {
   })
 
   it('Should log error and display id', async () => {
-    store.dispatch(startSession())
+    store.dispatch(api.endpoints.getUser.initiate())
     server.use(rest.get('/api/certificate/:id', (_, res, ctx) => res(ctx.status(500))))
     const pendingLogRequest = waitForRequest('POST', '/api/log/error')
 

--- a/apps/minaintyg/src/pages/Error/ErrorPage.test.tsx
+++ b/apps/minaintyg/src/pages/Error/ErrorPage.test.tsx
@@ -2,13 +2,13 @@ import { render } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { Route, RouterProvider, createMemoryRouter, createRoutesFromElements } from 'react-router-dom'
 import { waitForRequest } from '../../mocks/server'
-import { startSession } from '../../store/slice/session.slice'
+import { api } from '../../store/api'
 import { store } from '../../store/store'
 import { ErrorPage } from './ErrorPage'
 
 it('Should log error', async () => {
   const pendingLogRequest = waitForRequest('POST', '/api/log/error')
-  store.dispatch(startSession())
+  store.dispatch(api.endpoints.getUser.initiate())
   render(
     <Provider store={store}>
       <RouterProvider
@@ -29,7 +29,7 @@ it('Should log error', async () => {
 
 it('Should log login-failed error', async () => {
   const pendingLogRequest = waitForRequest('POST', '/api/log/error')
-  store.dispatch(startSession())
+  store.dispatch(api.endpoints.getUser.initiate())
   render(
     <Provider store={store}>
       <RouterProvider

--- a/apps/minaintyg/src/store/slice/session.slice.ts
+++ b/apps/minaintyg/src/store/slice/session.slice.ts
@@ -27,9 +27,6 @@ const sessionSlice = createSlice({
     reset() {
       return initialState
     },
-    startSession(state) {
-      state.hasSession = true
-    },
     endSession(state, { payload }: PayloadAction<{ reason: ErrorTypeEnum; errorId?: string }>) {
       state.hasSession = false
       state.hasSessionEnded = true
@@ -39,9 +36,7 @@ const sessionSlice = createSlice({
   },
   extraReducers: (builder) => {
     // Start session after successful user fetch
-    builder.addMatcher(api.endpoints.getUser.matchFulfilled, (state) => {
-      state.hasSession = true
-    })
+    builder.addMatcher(api.endpoints.getUser.matchFulfilled, () => ({ ...initialState, hasSession: true }))
 
     builder.addMatcher(isRejectedEndpoint, (state, action) => {
       const error = isQueryError(action) ? action.payload : null
@@ -69,5 +64,5 @@ const sessionSlice = createSlice({
   },
 })
 
-export const { startSession, endSession, reset } = sessionSlice.actions
+export const { endSession, reset } = sessionSlice.actions
 export const { reducer: sessionReducer, name: sessionReducerPath } = sessionSlice


### PR DESCRIPTION
* Do not call `ping` once session is over.
* Do not log failed `ping` requests unless it contains an error.
* Replace deprecated `AnyAction`.
* Remove unnecessary `startSession` reducer.