### PR TITLE
Fix broken e2e test

### DIFF
--- a/apps/webcert/README.md
+++ b/apps/webcert/README.md
@@ -50,6 +50,20 @@ VITE_WS_PROTOCOL=wss
 
 Start the application with `pnpm --filter @frontend/webcert dev` for only webcert or `pnpm start` for all watchers. Navigate to Webcert-frontend in a chromium-browser: <https://wc2.wc.localtest.me/welcome>
 
+### Mocked e2e tests
+
+Install browsers:
+
+```bash
+pnpm --filter @frontend/webcert exec playwright install
+```
+
+Run playwright tests with a UI:
+
+```bash
+pnpm --filter @frontend/webcert test:playwright --ui-host 127.0.0.1
+```
+
 ## Resources
 
 - [React](https://react.dev/) ─ Components

--- a/apps/webcert/src/faker/certificate/fakeCertificateMetaData.ts
+++ b/apps/webcert/src/faker/certificate/fakeCertificateMetaData.ts
@@ -46,6 +46,6 @@ export const fakeCertificateMetaData = (data?: PartialDeep<CertificateMetadata>)
     issuedBy: fakeStaff(data?.issuedBy),
     careUnit: fakeUnit(data?.careUnit),
     careProvider: fakeUnit(data?.careProvider),
-    messageTypes: data?.messageTypes?.map(fakeCertifiaMessageType) ?? [],
+    messageTypes: data?.messageTypes?.map(fakeCertifiaMessageType) ?? undefined,
   }
 }


### PR DESCRIPTION
`apps/webcert/tests/certificate/questions.spec.ts` tests are failing since the change to `messageTypes`