### PR TITLE
Allow custom hostname

### DIFF
--- a/apps/maintenance/vite.config.ts
+++ b/apps/maintenance/vite.config.ts
@@ -30,5 +30,6 @@ export default defineConfig({
   },
   server: {
     port: 5175,
+    allowedHosts: true,
   },
 })

--- a/apps/minaintyg/vite.config.ts
+++ b/apps/minaintyg/vite.config.ts
@@ -38,6 +38,7 @@ export default ({ mode }: UserConfig) => {
       port: 5174,
       proxy,
       strictPort: true,
+      allowedHosts: true,
       hmr: hmr ? { host: process.env.VITE_WS_HOST, protocol: hmrProtocol } : false,
     },
   })

--- a/apps/rehabstod/vite.config.ts
+++ b/apps/rehabstod/vite.config.ts
@@ -41,6 +41,7 @@ export default ({ mode }: UserConfig) => {
       port: 5173,
       proxy,
       strictPort: true,
+      allowedHosts: true,
       hmr: hmr ? { host: process.env.VITE_WS_HOST ?? 'rs2.rs.localtest.me', protocol: hmrProtocol } : false,
     },
   })

--- a/apps/webcert/vite.config.ts
+++ b/apps/webcert/vite.config.ts
@@ -49,6 +49,7 @@ export default ({ mode }: UserConfig) => {
       port: 3000,
       proxy,
       strictPort: true,
+      allowedHosts: true,
       hmr: hmr
         ? {
             host: process.env.VITE_WS_HOST ?? 'wc.localtest.me',


### PR DESCRIPTION
After updating vite it won't accept `localtest.me` domains to access the services by default.