### PR TITLE
Fix flaky test

### DIFF
--- a/apps/minaintyg/src/pages/Certificate/components/CertificateBody/CertificateBody.tsx
+++ b/apps/minaintyg/src/pages/Certificate/components/CertificateBody/CertificateBody.tsx
@@ -7,7 +7,7 @@ export function CertificateBody({ content }: { content: CertificateContent[] }) 
     <>
       {content.map(({ heading, body }) => (
         <div key={heading} className="border-b border-neutral-90">
-          <IDSAccordion headline={<h2>{heading}</h2>}>
+          <IDSAccordion lean headline={<h2>{heading}</h2>}>
             <DisplayHTML html={body} />
           </IDSAccordion>
         </div>

--- a/apps/minaintyg/src/pages/Certificate/components/CertificateBody/__snapshots__/CertificateBody.test.tsx.snap
+++ b/apps/minaintyg/src/pages/Certificate/components/CertificateBody/__snapshots__/CertificateBody.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Should render h1 heading as expected 1`] = `
     class="border-b border-neutral-90"
   >
     <div
-      class="ids-accordion"
+      class="ids-accordion ids-accordion--lean"
     >
       <div
         aria-controls=":r2:"
@@ -45,7 +45,7 @@ exports[`Should render h2 heading as expected 1`] = `
     class="border-b border-neutral-90"
   >
     <div
-      class="ids-accordion"
+      class="ids-accordion ids-accordion--lean"
     >
       <div
         aria-controls=":r3:"
@@ -84,7 +84,7 @@ exports[`Should render h3 heading as expected 1`] = `
     class="border-b border-neutral-90"
   >
     <div
-      class="ids-accordion"
+      class="ids-accordion ids-accordion--lean"
     >
       <div
         aria-controls=":r4:"
@@ -123,7 +123,7 @@ exports[`Should render h4 heading as expected 1`] = `
     class="border-b border-neutral-90"
   >
     <div
-      class="ids-accordion"
+      class="ids-accordion ids-accordion--lean"
     >
       <div
         aria-controls=":r5:"
@@ -162,7 +162,7 @@ exports[`Should render h5 heading as expected 1`] = `
     class="border-b border-neutral-90"
   >
     <div
-      class="ids-accordion"
+      class="ids-accordion ids-accordion--lean"
     >
       <div
         aria-controls=":r6:"
@@ -201,7 +201,7 @@ exports[`Should render h6 heading as expected 1`] = `
     class="border-b border-neutral-90"
   >
     <div
-      class="ids-accordion"
+      class="ids-accordion ids-accordion--lean"
     >
       <div
         aria-controls=":r7:"
@@ -240,7 +240,7 @@ exports[`Should render html as expected 1`] = `
     class="border-b border-neutral-90"
   >
     <div
-      class="ids-accordion"
+      class="ids-accordion ids-accordion--lean"
     >
       <div
         aria-controls=":r0:"
@@ -277,7 +277,7 @@ exports[`Should render table as expected 1`] = `
     class="border-b border-neutral-90"
   >
     <div
-      class="ids-accordion"
+      class="ids-accordion ids-accordion--lean"
     >
       <div
         aria-controls=":r1:"


### PR DESCRIPTION
Snapshot tests for `CertificatePage` sometimes fails because `IDSAccordion` adds lean when put inside a `IDSCard`. This mitigates that by adding lean property from the start.