### PR TITLE
Wrong selector function

### DIFF
--- a/apps/webcert/src/page/SelectUnitPage.tsx
+++ b/apps/webcert/src/page/SelectUnitPage.tsx
@@ -7,7 +7,7 @@ import SimpleTable from '../components/Table/SimpleTable'
 import ModalBase from '../components/utils/Modal/ModalBase'
 import logo from '../images/webcert_logo.png'
 import { useAppSelector } from '../store/store'
-import { getCareProviders, getSelectUnitHeading, getUser } from '../store/user/userSelectors'
+import { getCareProviders, getSelectUnitHeading } from '../store/user/userSelectors'
 import type { CareUnit, Unit } from '../types'
 
 const ModalBaseLarge = styled(ModalBase)`
@@ -30,11 +30,10 @@ function SelectUnitRow({ unit, certificateId }: { unit: CareUnit | Unit; certifi
 
 export function SelectUnitPage() {
   const { certificateId } = useParams<{ certificateId: string }>()
-  const user = useAppSelector(getUser)
   const modalTitle = useAppSelector(getSelectUnitHeading)
   const careProviders = useAppSelector(getCareProviders)
 
-  if (!user || !certificateId) {
+  if (!certificateId) {
     return null
   }
 

--- a/apps/webcert/src/page/SelectUnitPage.tsx
+++ b/apps/webcert/src/page/SelectUnitPage.tsx
@@ -7,8 +7,7 @@ import SimpleTable from '../components/Table/SimpleTable'
 import ModalBase from '../components/utils/Modal/ModalBase'
 import logo from '../images/webcert_logo.png'
 import { useAppSelector } from '../store/store'
-import { getUser } from '../store/user/userActions'
-import { getCareProviders, getSelectUnitHeading } from '../store/user/userSelectors'
+import { getCareProviders, getSelectUnitHeading, getUser } from '../store/user/userSelectors'
 import type { CareUnit, Unit } from '../types'
 
 const ModalBaseLarge = styled(ModalBase)`


### PR DESCRIPTION
`SelectUnitPage` has been using an action instead of a selector, this has always returned true since an action returns an object but not a user object. Since `user` is not being used here, it should be safe to remove.