### PR TITLE
K1J-1358: Add route for /questions endpoint.

### DIFF
--- a/apps/webcert/src/Router.tsx
+++ b/apps/webcert/src/Router.tsx
@@ -54,6 +54,7 @@ export function Router() {
         <Route path="certificate/:certificateId/sign/:error" element={<CertificatePage />} />
         <Route path="certificate/:certificateId/launch-unit-selection" element={<SelectUnitPage />} />
         <Route path="certificate/:certificateId" element={<CertificatePage />} />
+        <Route path="certificate/:certificateId/questions" element={<CertificatePage />} />
         <Route path="welcome" element={<Welcome />} />
         <Route path="welcome.html" element={<Welcome />} />
         <Route path="error" element={<ErrorPage />} />


### PR DESCRIPTION
The error occurs because React Router v6 matches routes strictly. A route defined only up to the certificate ID no longer matches URLs that include additional segments, such as /questions. In earlier versions this often worked implicitly, but in v6 you must explicitly define or allow sub-segments for the match to succeed.