### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
   test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
@@ -45,6 +47,8 @@ jobs:
   lint:
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Check out code

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,6 +7,8 @@ env:
   LEGACY_SUPPORT: false
 jobs:
   playwright:
+    permissions:
+      contents: read
     name: 'Playwright Tests'
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Potential fix for [https://github.com/sklintyg/frontend/security/code-scanning/6](https://github.com/sklintyg/frontend/security/code-scanning/6)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions for the job in question by adding a `permissions` key. Since the workflow appears to only require reading repository content (checking out code and running tests) and does not perform any actions that require write access (such as creating issues, posting pull request comments, etc.), setting `permissions: contents: read` at the job level is the minimal and appropriate fix. If the entire workflow needs restrictive permissions, it can also be placed at the root, but per the CodeQL highlight (job line) and to be as minimally invasive as possible, we'll add it under the `playwright` job. This means editing the `.github/workflows/playwright.yml` file, and adding:

```yaml
permissions:
  contents: read
```

directly under the `playwright:` job block, before `name:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
