### PR TITLE
K1J-1366: Perform search after updating default filter values

### DIFF
--- a/apps/webcert/src/feature/list/ListTable.tsx
+++ b/apps/webcert/src/feature/list/ListTable.tsx
@@ -100,7 +100,7 @@ export function ListTable({
       )
 
       dispatch(updateIsSortingList(true))
-      dispatch(performListSearch)
+      dispatch(performListSearch())
     }
   }
 

--- a/apps/webcert/src/feature/list/listUtils.test.tsx
+++ b/apps/webcert/src/feature/list/listUtils.test.tsx
@@ -8,7 +8,7 @@ import {
   fakeTextFilter,
 } from '../../faker/list/fakeListFilterConfig'
 import { ListFilterType } from '../../types'
-import { getListFilterDefaultValue, isFilterValueDefault } from './listUtils'
+import { getListFilterDefaultValue, isFilterDefault, isFilterValueDefault } from './listUtils'
 
 describe('listUtils', () => {
   describe('getListFilterDefaultValue', () => {
@@ -51,72 +51,86 @@ describe('listUtils', () => {
   describe('isFilterValueDefault', () => {
     it('should return true if text value is empty string', () => {
       const result = isFilterValueDefault(fakeTextFilter(), { type: ListFilterType.TEXT, value: '' })
-      expect(result).toBeTruthy()
+      expect(result).toBe(true)
     })
 
     it('should return false if text value is not empty string', () => {
       const result = isFilterValueDefault(fakeTextFilter(), { type: ListFilterType.TEXT, value: 'test' })
-      expect(result).toBeFalsy()
+      expect(result).toBe(false)
     })
 
     it('should return true person id is empty string', () => {
       const result = isFilterValueDefault(fakePersonIdFilter(), { type: ListFilterType.PERSON_ID, value: '' })
-      expect(result).toBeTruthy()
+      expect(result).toBe(true)
     })
 
     it('should return false person id is not empty string', () => {
       const result = isFilterValueDefault(fakePersonIdFilter(), { type: ListFilterType.PERSON_ID, value: '191212121212' })
-      expect(result).toBeFalsy()
+      expect(result).toBe(false)
     })
 
     it('should return true if value is id of default option', () => {
       const result = isFilterValueDefault(fakeSelectFilter(), { type: ListFilterType.SELECT, value: 'option2' })
-      expect(result).toBeTruthy()
+      expect(result).toBe(true)
     })
 
     it('should return false if value is not id of default option', () => {
       const result = isFilterValueDefault(fakeSelectFilter(), { type: ListFilterType.SELECT, value: 'option1' })
-      expect(result).toBeFalsy()
+      expect(result).toBe(false)
     })
 
     it('should return true if date is default value', () => {
       const result = isFilterValueDefault(fakeDateRangeFilter(), { type: ListFilterType.DATE_RANGE, to: 'default1', from: 'default2' })
-      expect(result).toBeTruthy()
+      expect(result).toBe(true)
     })
 
     it('should return false if date is not default value', () => {
       const result = isFilterValueDefault(fakeDateRangeFilter(), { type: ListFilterType.DATE_RANGE, to: '', from: '' })
-      expect(result).toBeFalsy()
+      expect(result).toBe(false)
     })
 
     it('should return true if default order value', () => {
       const result = isFilterValueDefault(fakeOrderFilter(), { type: ListFilterType.ORDER, value: 'defaultOrder' })
-      expect(result).toBeTruthy()
+      expect(result).toBe(true)
     })
 
     it('should return false if not default order value', () => {
       const result = isFilterValueDefault(fakeOrderFilter(), { type: ListFilterType.ORDER, value: 'notDefaultOrder' })
-      expect(result).toBeFalsy()
+      expect(result).toBe(false)
     })
 
     it('should return true if default boolean value', () => {
       const result = isFilterValueDefault(fakeBooleanFilter(), { type: ListFilterType.BOOLEAN, value: true })
-      expect(result).toBeTruthy()
+      expect(result).toBe(true)
     })
 
     it('should return false if not default boolean value', () => {
       const result = isFilterValueDefault(fakeBooleanFilter(), { type: ListFilterType.BOOLEAN, value: false })
-      expect(result).toBeFalsy()
+      expect(result).toBe(false)
     })
 
     it('should return true if first page size value', () => {
       const result = isFilterValueDefault(fakePageSizeFilter(), { type: ListFilterType.NUMBER, value: 10 })
-      expect(result).toBeTruthy()
+      expect(result).toBe(true)
     })
 
     it('should return false if not first page size value', () => {
       const result = isFilterValueDefault(fakePageSizeFilter(), { type: ListFilterType.NUMBER, value: 20 })
-      expect(result).toBeFalsy()
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('isFilterDefault', () => {
+    it('Should return true when all filters have default value', () => {
+      const result = isFilterDefault([fakeTextFilter({ id: 'SOME_FILTER' })], { SOME_FILTER: { type: ListFilterType.TEXT, value: '' } })
+      expect(result).toBe(true)
+    })
+
+    it('Should return false when any filters doesnt have default value', () => {
+      const result = isFilterDefault([fakeTextFilter({ id: 'SOME_FILTER' })], {
+        SOME_FILTER: { type: ListFilterType.TEXT, value: 'Not default' },
+      })
+      expect(result).toBe(false)
     })
   })
 })

--- a/apps/webcert/src/feature/list/listUtils.tsx
+++ b/apps/webcert/src/feature/list/listUtils.tsx
@@ -63,18 +63,15 @@ export const getListFilterDefaultValue = (filter: ListFilterConfig): ListFilterV
 }
 
 export const isFilterDefault = (configs: ListFilterConfig[] | undefined, values?: Record<string, ListFilterValue | undefined>): boolean => {
-  let isDefault = true
   if (!configs || !values) {
     return false
   }
-  Object.keys(values).forEach((key) => {
+
+  return Object.keys(values).every((key) => {
     const matchedConfig = configs.find((config) => config.id === key)
     const defaultValue = matchedConfig ? getListFilterDefaultValue(matchedConfig) : null
-    if (!isEqual(values[key], defaultValue)) {
-      isDefault = false
-    }
+    return isEqual(values[key], defaultValue)
   })
-  return isDefault
 }
 
 export const isFilterValueDefault = (config: ListFilterConfig, value: ListFilterValue): boolean => {

--- a/apps/webcert/src/feature/list/pagination/ListPagination.tsx
+++ b/apps/webcert/src/feature/list/pagination/ListPagination.tsx
@@ -14,7 +14,7 @@ const ListPagination = () => {
   const handlePageChange = useCallback(
     (startFrom: number) => {
       dispatch(updateActiveListFilterValue({ id: 'START_FROM', filterValue: { type: ListFilterType.NUMBER, value: startFrom } }))
-      dispatch(performListSearch)
+      dispatch(performListSearch())
     },
     [dispatch]
   )

--- a/apps/webcert/src/page/CreatePage.tsx
+++ b/apps/webcert/src/page/CreatePage.tsx
@@ -9,7 +9,7 @@ import { ListContainer } from '../feature/list/ListContainer'
 import { isFilterDefault } from '../feature/list/listUtils'
 import { listImage, noDraftsImage } from '../images'
 import { resetCertificateState, updateShouldRouteAfterDelete } from '../store/certificate/certificateActions'
-import { getActiveListConfig, getActiveListFilter, getListTotalCount } from '../store/list/listSelectors'
+import { getActiveListConfig, getActiveListFilter, getIsLoadingList, getListTotalCount } from '../store/list/listSelectors'
 import { getPatient } from '../store/patient/patientActions'
 import { getActivePatient } from '../store/patient/patientSelectors'
 import { useAppSelector } from '../store/store'
@@ -28,6 +28,7 @@ const CreatePage = () => {
   const filter = useAppSelector(getActiveListFilter, shallowEqual)
   const patient = useAppSelector(getActivePatient)
   const user = useAppSelector(getUser)
+  const isLoadingList = useAppSelector(getIsLoadingList)
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -60,7 +61,7 @@ const CreatePage = () => {
               <div className="iu-mt-800">
                 <ListContainer
                   type={ListType.PREVIOUS_CERTIFICATES}
-                  showMessageForEmptyList={isFilterDefault(config?.filters, filter?.values) && totalCount === 0}
+                  showMessageForEmptyList={!isLoadingList && isFilterDefault(config?.filters, filter?.values) && totalCount === 0}
                   icon={listImage}
                   emptyListIcon={noDraftsImage}
                 />

--- a/apps/webcert/src/page/SignedCertificatesPage.tsx
+++ b/apps/webcert/src/page/SignedCertificatesPage.tsx
@@ -5,6 +5,7 @@ import {
   getActiveListConfig,
   getActiveListFilter,
   getHasUpdatedConfig,
+  getIsLoadingList,
   getIsLoadingListConfig,
   getListTotalCount,
 } from '../store/list/listSelectors'
@@ -24,6 +25,7 @@ export function SignedCertificatesPage() {
   const config = useAppSelector(getActiveListConfig, shallowEqual)
   const filter = useAppSelector(getActiveListFilter, shallowEqual)
   const isLoadingListConfig = useAppSelector(getIsLoadingListConfig)
+  const isLoadingList = useAppSelector(getIsLoadingList)
   const totalCount = useAppSelector(getListTotalCount)
   const hasUpdatedConfig = useAppSelector(getHasUpdatedConfig)
 
@@ -50,7 +52,7 @@ export function SignedCertificatesPage() {
       >
         <ListContainer
           type={ListType.CERTIFICATES}
-          showMessageForEmptyList={isFilterDefault(config?.filters, filter?.values) && totalCount === 0}
+          showMessageForEmptyList={!isLoadingList && isFilterDefault(config?.filters, filter?.values) && totalCount === 0}
           icon={undefined}
           emptyListIcon={noDraftsImage}
         />

--- a/apps/webcert/src/store/list/listMiddleware.ts
+++ b/apps/webcert/src/store/list/listMiddleware.ts
@@ -324,12 +324,6 @@ const handleGetListConfigSuccess =
     if (getState().ui.uiList.activeListType === listType) {
       dispatch(updateActiveListConfig(action.payload))
       dispatch(updateDefaultListFilterValues(action.payload))
-      dispatch(clearListError())
-      dispatch(updateIsLoadingListConfig(false))
-      dispatch(performListSearch)
-      if (getState().ui.uiList.hasUpdatedConfig === true) {
-        dispatch(updateListConfig())
-      }
     }
   }
 
@@ -367,6 +361,13 @@ const handleUpdateDefaultFilterValues =
         const defaultValue = getListFilterDefaultValue(filter)
         dispatch(updateActiveListFilterValue({ filterValue: defaultValue, id: filter.id }))
       })
+    }
+
+    dispatch(clearListError())
+    dispatch(updateIsLoadingListConfig(false))
+    dispatch(performListSearch())
+    if (getState().ui.uiList.hasUpdatedConfig === true) {
+      dispatch(updateListConfig())
     }
   }
 


### PR DESCRIPTION
The "empty list message" is displayed when all filters have default values and the search result is 0. When resetting the filters they return to default and if the performed search had a result of 0 the empty message would be shown. To solve this, I make sure that we do another search once filters are reset.