### PR TITLE
K1J-1422: Update so that unit of measurement is not required for UvInteger component.

### DIFF
--- a/apps/webcert/src/components/UnifiedView/UvInteger/UvInteger.tsx
+++ b/apps/webcert/src/components/UnifiedView/UvInteger/UvInteger.tsx
@@ -4,9 +4,9 @@ import { Badge } from '../Badge'
 export const UvInteger = ({ value, config }: { value: ValueInteger; config: ConfigUeInteger }) => (
   <Badge>
     {typeof value.value === 'number' && value.value !== null
-      ? value.value.toString() + config.unitOfMeasurement
+      ? value.value.toString() + (config.unitOfMeasurement ?? '')
       : value.value === 0 || Object.is(value.value, -0)
-        ? '0' + config.unitOfMeasurement
+        ? '0' + (config.unitOfMeasurement ?? '')
         : 'Ej angivet'}
   </Badge>
 )


### PR DESCRIPTION
unitOfMeasurement should not be required for UvInteger.